### PR TITLE
LoggerFromContext with test

### DIFF
--- a/telemetry/logger.go
+++ b/telemetry/logger.go
@@ -1,0 +1,22 @@
+package telemetry
+
+import (
+	"context"
+	"log/slog"
+)
+
+type loggerContextKey struct{}
+
+// NewContextWithLogger returns a new context carrying the given slog.Logger.
+func NewContextWithLogger(ctx context.Context, logger *slog.Logger) context.Context {
+	return context.WithValue(ctx, loggerContextKey{}, logger)
+}
+
+// LoggerFromContext retrieves the slog.Logger stored by NewContextWithLogger.
+// Falls back to slog.Default() when none is present.
+func LoggerFromContext(ctx context.Context) *slog.Logger {
+	if l, ok := ctx.Value(loggerContextKey{}).(*slog.Logger); ok {
+		return l
+	}
+	return slog.Default()
+}

--- a/telemetry/logger_test.go
+++ b/telemetry/logger_test.go
@@ -1,0 +1,42 @@
+package telemetry
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"testing/synctest"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoggerFromContext(t *testing.T) {
+	// nolint:thelper // synctest.Test takes a test function, not a helper
+	synctest.Test(t, func(t *testing.T) {
+		ctx := context.Background()
+		var buf bytes.Buffer
+		tel, shutdown := New(ctx, "test-logger", WithLocalWriter(&buf),
+			WithAttributes(map[string]string{
+				"attribute": "value",
+			}))
+
+		// Insert logger into context:
+		ctx = NewContextWithLogger(ctx, tel.Logger().With("some-field", "some-value"))
+
+		logger := LoggerFromContext(ctx)
+
+		logger.InfoContext(ctx, "testing testing")
+
+		require.NoError(t, shutdown(ctx))
+
+		expectedContents := []string{
+			`sev=INFO msg="testing testing" attribute="value" some-field="some-value"`,
+		}
+
+		loggedContent := buf.Bytes()
+		for _, e := range expectedContents {
+			if !bytes.Contains(loggedContent, []byte(e)) {
+				t.Errorf("Expected log to contain %q, but it did not. Full log:\n%s", e, loggedContent)
+			}
+		}
+	})
+}


### PR DESCRIPTION
Lite forslag om å putte en `slog.Logger` (helst gitt av `Provider.Logger()`) i context, i lag med en funksjon for å hente ut denne loggeren fra kontekst.