### PR TITLE
release: Support minor bumps and skip labels

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: read
 
 concurrency:
   group: release
@@ -22,21 +23,42 @@ jobs:
           fetch-depth: 0
 
       - name: Tag changed modules
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           changed_files=$(git diff --name-only ${{ github.event.before }} HEAD)
+
+          labels=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" \
+            --jq '.[].labels[].name' 2>/dev/null || true)
 
           for gomod in $(find . -name go.mod -not -path ./examples/go.mod); do
             module=$(dirname "$gomod" | sed 's|^\./||')
             if echo "$changed_files" | grep -q "^${module}/"; then
+              if echo "$labels" | grep -qx "no-release:${module}" \
+                || echo "$labels" | grep -qx "no-release"; then
+                echo "Skipping ${module} (no-release label)"
+                continue
+              fi
+
+              bump=patch
+              if echo "$labels" | grep -qx "minor:${module}" \
+                || echo "$labels" | grep -qx "minor"; then
+                bump=minor
+              fi
+
               latest=$(git tag -l "${module}/v*" --sort=-v:refname | head -1)
               if [ -z "$latest" ]; then
                 next="${module}/v0.1.0"
               else
                 version="${latest#${module}/v}"
                 IFS='.' read -r major minor patch <<< "$version"
-                next="${module}/v${major}.${minor}.$((patch + 1))"
+                if [ "$bump" = "minor" ]; then
+                  next="${module}/v${major}.$((minor + 1)).0"
+                else
+                  next="${module}/v${major}.${minor}.$((patch + 1))"
+                fi
               fi
-              echo "Tagging ${next}"
+              echo "Tagging ${next} (${bump})"
               git tag "$next"
             fi
           done

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,6 +122,26 @@ duration, status codes, and request counts.
 4. Link any related issues
 5. Wait for review and address any feedback
 
+### Releases
+
+Each module is tagged automatically when the PR merges to `main`. The bump
+level is controlled by labels on the PR:
+
+- No label → patch bump (`v1.2.3` → `v1.2.4`) for every changed module.
+- `minor` → minor bump (`v1.2.3` → `v1.3.0`) for every changed module.
+- `minor:<module>` (e.g. `minor:telemetry`) → minor bump for that module
+  only; other changed modules still get a patch bump. Use this when one PR
+  touches several modules but only some warrant a minor.
+- `no-release` / `no-release:<module>` → skip automatic tagging entirely
+  (for the whole PR, or scoped to one module). Use this for docs-only
+  changes that touched module files, or when you plan to tag manually
+  (e.g. a major bump).
+
+Major bumps are not automated. Tag them manually when needed — for v0→v1
+graduation a plain `git tag <module>/v1.0.0` is enough, and v2+ also
+requires updating the module path in `go.mod`. Pair the breaking-change PR
+with `no-release` so it doesn't get auto-tagged as a patch.
+
 ## Adding New Packages
 
 When adding a new reusable package to this repository:


### PR DESCRIPTION
  Read PR labels in the release workflow so each changed module can be
  bumped minor (`minor` / `minor:<module>`) or skipped entirely
  (`no-release` / `no-release:<module>`). Default behavior is unchanged
  — patch bump for every changed module.