### PR TITLE
:bug: fix system for consumer

### DIFF
--- a/.golangci.toml
+++ b/.golangci.toml
@@ -33,7 +33,7 @@ enable = [
     "govet",
     "staticcheck",
     "errcheck",
-    "gomodguard",
+    "gomodguard_v2",
     "forbidigo",
     "rowserrcheck",
     "sqlclosecheck",

--- a/.golangci.toml
+++ b/.golangci.toml
@@ -33,7 +33,7 @@ enable = [
     "govet",
     "staticcheck",
     "errcheck",
-    "gomodguard_v2",
+    "gomodguard",
     "forbidigo",
     "rowserrcheck",
     "sqlclosecheck",

--- a/kafkarator/claimcheck/arn_e2e_test.go
+++ b/kafkarator/claimcheck/arn_e2e_test.go
@@ -102,7 +102,7 @@ func TestClaimCheckARN_ProducerAndConsumerAgree_E2E(t *testing.T) {
 		return claimcheck.NewFakeS3Client(), nil
 	}
 	require.NoError(t, claimcheck.ResolveForTest(
-		factory, consumerSystem, &fakeEnvelopeDeserializer{envelope: envelope}, topic, []byte("wire"),
+		factory, &fakeEnvelopeDeserializer{envelope: envelope}, topic, []byte("wire"),
 	))
 
 	// The consumer used the producer's system, not its own.
@@ -133,8 +133,7 @@ func TestClaimCheckARN_SharedProduct_E2E(t *testing.T) {
 		topic          = "test.water--obs.measurements--v1"
 	)
 
-	owner := claimcheck.DefaultSystemResolver(topic)
-	require.Equal(t, "data-definitions", owner)
+	const owner = "data-definitions" // topic-derived owning system for a shared product
 
 	bucket := claimcheck.DefaultBucketResolver(topic)
 
@@ -150,7 +149,7 @@ func TestClaimCheckARN_SharedProduct_E2E(t *testing.T) {
 		return claimcheck.NewFakeS3Client(), nil
 	}
 	require.NoError(t, claimcheck.ResolveForTest(
-		factory, consumerSystem, &fakeEnvelopeDeserializer{envelope: envelope}, topic, []byte("wire"),
+		factory, &fakeEnvelopeDeserializer{envelope: envelope}, topic, []byte("wire"),
 	))
 	require.Equal(t, owner, usedSystem)
 	require.NotEqual(t, consumerSystem, usedSystem)

--- a/kafkarator/claimcheck/arn_e2e_test.go
+++ b/kafkarator/claimcheck/arn_e2e_test.go
@@ -1,0 +1,123 @@
+package claimcheck_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	kafkarator "github.com/hafslundkraft/golib/kafkarator"
+	"github.com/hafslundkraft/golib/kafkarator/claimcheck"
+)
+
+// TestClaimCheckARN_FromEnvVars_E2E exercises the full path that a real Happi
+// workload follows: the operator-injected environment is read by
+// kafkarator.ConfigFromEnvVars, the resulting SystemName/Env flow into the
+// claimcheck S3 client construction, and the Ceph IAM role ARN is derived from
+// them together with the topic-derived bucket.
+//
+// It mirrors the env block injected into a pod such as sine-wave-writer:
+//
+//	HAPPI_SYSTEM_NAME=snappi-demo
+//	HAPPI_ENV=dev
+//	HAPPI_WORKLOAD_NAME=sine-wave-writer
+//	HAPPI_IDP_ISSUER_URL=https://login.dev.happi.hafslund.no/realms/happi
+func TestClaimCheckARN_FromEnvVars_E2E(t *testing.T) {
+	// Happi-injected environment, mirroring a real pod. Secret-backed values
+	// (KAFKA_CA_CERT) are given dummy contents — they are not validated by
+	// ConfigFromEnvVars, only required to be non-empty.
+	t.Setenv("KAFKA_AUTH_TYPE", "sasl")
+	t.Setenv("KAFKA_BROKER", "kafkabroker")
+	t.Setenv("KAFKA_CA_CERT", "dummy-ca-cert")
+	t.Setenv("KAFKA_SCHEMA_REGISTRY_URL", "https://kafkabroker:23100")
+	t.Setenv("KAFKA_USERNAME", "username")
+	t.Setenv("KAFKA_PASSWORD", "dummy-password")
+	t.Setenv("HAPPI_IDP_ISSUER_URL", "https://dummy-issuer-url")
+
+	// use vars from happi.docs
+	t.Setenv("HAPPI_SYSTEM_NAME", "billing")
+	t.Setenv("HAPPI_ENV", "test")
+	t.Setenv("HAPPI_WORKLOAD_NAME", "my-app")
+
+	// kafkarator reads the environment exactly as it does in production.
+	cfg, err := kafkarator.ConfigFromEnvVars()
+	require.NoError(t, err)
+	require.Equal(t, "billing", cfg.SystemName)
+	require.Equal(t, "test", cfg.Env)
+
+	const topic = "billing.test.my-app"
+	bucket := claimcheck.DefaultBucketResolver(topic)
+
+	// Build a S3 client through the real construction path and
+	//    read back the role ARN it computed.
+	for _, tc := range []struct {
+		name   string
+		access string
+	}{
+		{"writer", "rw"},
+		{"reader", "r"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			gotARN, err := claimcheck.RoleARNForClient(bucket, tc.access, cfg.SystemName, cfg.Env)
+			require.NoError(t, err)
+
+			wantARN := fmt.Sprintf(
+				"arn:aws:iam:::role/happi/billing/test/%s/billing.test.%s.%s",
+				bucket, bucket, tc.access,
+			)
+			assert.Equal(t, wantARN, gotARN)
+		})
+	}
+}
+
+// TestClaimCheckARN_ProducerAndConsumerAgree_E2E proves the fix end-to-end: a
+// consumer running in a DIFFERENT system than the producer must assume the
+// producer's role to read the payload, because the bucket is owned by the
+// producing system. The producer's writer role and the consumer's reader role
+// must therefore resolve to the same Ceph IAM role, differing only in the
+// trailing access component (rw vs r).
+func TestClaimCheckARN_ProducerAndConsumerAgree_E2E(t *testing.T) {
+	const (
+		producerSystem = "billing"
+		consumerSystem = "analytics" // deliberately NOT the producer's system
+		env            = "test"
+		topic          = "billing.test.invoices"
+	)
+	bucket := claimcheck.DefaultBucketResolver(topic)
+
+	// Producer side: a writer in "billing" assumes the rw role for the bucket.
+	producerARN, err := claimcheck.ClaimCheckRoleARN(producerSystem, env, bucket, "rw")
+	require.NoError(t, err)
+
+	// Consumer side: a processor whose OWN system is "analytics" resolves an
+	// envelope produced by "billing". Capture the (system, bucket) the reader
+	// factory is asked to build so we can derive the reader ARN production would.
+	envelope := envelopeForTopic(topic, producerSystem)
+	var usedSystem, usedBucket string
+	factory := func(system, b string) (claimcheck.S3Reader, error) {
+		usedSystem, usedBucket = system, b
+		return claimcheck.NewFakeS3Client(), nil
+	}
+	require.NoError(t, claimcheck.ResolveForTest(
+		factory, consumerSystem, &fakeEnvelopeDeserializer{env: envelope}, topic, []byte("wire"),
+	))
+
+	// The consumer used the producer's system, not its own.
+	require.Equal(t, producerSystem, usedSystem)
+	require.NotEqual(t, consumerSystem, usedSystem)
+	require.Equal(t, bucket, usedBucket)
+
+	consumerARN, err := claimcheck.ClaimCheckRoleARN(usedSystem, env, usedBucket, "r")
+	require.NoError(t, err)
+
+	// Both sides target the same role: identical except for the access suffix.
+	assert.Equal(t, "arn:aws:iam:::role/happi/billing/test/"+bucket+"/billing.test."+bucket+".rw", producerARN)
+	assert.Equal(t, "arn:aws:iam:::role/happi/billing/test/"+bucket+"/billing.test."+bucket+".r", consumerARN)
+	assert.Equal(t,
+		strings.TrimSuffix(producerARN, ".rw"),
+		strings.TrimSuffix(consumerARN, ".r"),
+		"producer and consumer must resolve to the same role, differing only in access",
+	)
+}

--- a/kafkarator/claimcheck/arn_e2e_test.go
+++ b/kafkarator/claimcheck/arn_e2e_test.go
@@ -122,3 +122,52 @@ func TestClaimCheckARN_ProducerAndConsumerAgree_E2E(t *testing.T) {
 		"producer and consumer must resolve to the same role, differing only in access",
 	)
 }
+
+// TestClaimCheckARN_SharedProduct_E2E proves that for a shared data-product
+// neither the producer nor the consumer owns the bucket: both derive
+// "data-definitions" from the topic and resolve to the same role.
+func TestClaimCheckARN_SharedProduct_E2E(t *testing.T) {
+	const (
+		consumerSystem = "analytics"
+		env            = "test"
+		topic          = "test.water--obs.measurements--v1"
+	)
+
+	owner := claimcheck.DefaultSystemResolver(topic)
+	require.Equal(t, "data-definitions", owner)
+
+	bucket := claimcheck.DefaultBucketResolver(topic)
+
+	// Producer side: the writer assumes the owner's rw role.
+	producerARN, err := claimcheck.ClaimCheckRoleARN(owner, env, bucket, "rw")
+	require.NoError(t, err)
+
+	// Consumer side: the writer stamped the resolved owner onto the envelope.
+	envelope := envelopeForTopic(topic, owner)
+	var usedSystem, usedBucket string
+	factory := func(system, b string) (claimcheck.S3Reader, error) {
+		usedSystem, usedBucket = system, b
+		return claimcheck.NewFakeS3Client(), nil
+	}
+	require.NoError(t, claimcheck.ResolveForTest(
+		factory, consumerSystem, &fakeEnvelopeDeserializer{env: envelope}, topic, []byte("wire"),
+	))
+	require.Equal(t, owner, usedSystem)
+	require.NotEqual(t, consumerSystem, usedSystem)
+
+	consumerARN, err := claimcheck.ClaimCheckRoleARN(usedSystem, env, usedBucket, "r")
+	require.NoError(t, err)
+
+	wantBase := fmt.Sprintf(
+		"arn:aws:iam:::role/happi/data-definitions/test/%s/data-definitions.test.%s",
+		bucket,
+		bucket,
+	)
+	assert.Equal(t, wantBase+".rw", producerARN)
+	assert.Equal(t, wantBase+".r", consumerARN)
+	assert.Equal(t,
+		strings.TrimSuffix(producerARN, ".rw"),
+		strings.TrimSuffix(consumerARN, ".r"),
+		"producer and consumer must resolve to the same data-definitions role",
+	)
+}

--- a/kafkarator/claimcheck/arn_e2e_test.go
+++ b/kafkarator/claimcheck/arn_e2e_test.go
@@ -102,7 +102,7 @@ func TestClaimCheckARN_ProducerAndConsumerAgree_E2E(t *testing.T) {
 		return claimcheck.NewFakeS3Client(), nil
 	}
 	require.NoError(t, claimcheck.ResolveForTest(
-		factory, consumerSystem, &fakeEnvelopeDeserializer{env: envelope}, topic, []byte("wire"),
+		factory, consumerSystem, &fakeEnvelopeDeserializer{envelope: envelope}, topic, []byte("wire"),
 	))
 
 	// The consumer used the producer's system, not its own.
@@ -150,7 +150,7 @@ func TestClaimCheckARN_SharedProduct_E2E(t *testing.T) {
 		return claimcheck.NewFakeS3Client(), nil
 	}
 	require.NoError(t, claimcheck.ResolveForTest(
-		factory, consumerSystem, &fakeEnvelopeDeserializer{env: envelope}, topic, []byte("wire"),
+		factory, consumerSystem, &fakeEnvelopeDeserializer{envelope: envelope}, topic, []byte("wire"),
 	))
 	require.Equal(t, owner, usedSystem)
 	require.NotEqual(t, consumerSystem, usedSystem)

--- a/kafkarator/claimcheck/arn_e2e_test.go
+++ b/kafkarator/claimcheck/arn_e2e_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	kafkarator "github.com/hafslundkraft/golib/kafkarator"
+
 	"github.com/hafslundkraft/golib/kafkarator/claimcheck"
 )
 

--- a/kafkarator/claimcheck/envelope.go
+++ b/kafkarator/claimcheck/envelope.go
@@ -15,6 +15,13 @@ type Envelope struct {
 	// Topic is the Kafka topic this envelope was produced to.
 	Topic string `avro:"topic"`
 
+	// System is the Happi system name that produced this envelope. Because a
+	// claim-check bucket is owned by the producing system, readers use System to
+	// assume the producer's Ceph IAM role when fetching the payload. Legacy
+	// envelopes written before this field existed decode with System == "", in
+	// which case the reader falls back to its own system name.
+	System string `avro:"system"`
+
 	// RecordCount is the number of logical records in the Parquet file.
 	RecordCount int64 `avro:"record_count"`
 

--- a/kafkarator/claimcheck/envelope.go
+++ b/kafkarator/claimcheck/envelope.go
@@ -15,11 +15,11 @@ type Envelope struct {
 	// Topic is the Kafka topic this envelope was produced to.
 	Topic string `avro:"topic"`
 
-	// System is the Happi system name that produced this envelope. Because a
-	// claim-check bucket is owned by the producing system, readers use System to
-	// assume the producer's Ceph IAM role when fetching the payload. Legacy
-	// envelopes written before this field existed decode with System == "", in
-	// which case the reader falls back to its own system name.
+	// System is the Happi system name that owns this envelope's claim-check
+	// bucket, derived from the topic by the writer (never overridable). Because a
+	// claim-check bucket is owned by that system, readers use System to assume its
+	// Ceph IAM role when fetching the payload. It is always set; a reader rejects
+	// an envelope with System == "" as malformed.
 	System string `avro:"system"`
 
 	// RecordCount is the number of logical records in the Parquet file.

--- a/kafkarator/claimcheck/envelope_test.go
+++ b/kafkarator/claimcheck/envelope_test.go
@@ -10,9 +10,9 @@ import (
 )
 
 func TestClaimCheckRoleARN_CorrectFormat(t *testing.T) {
-	arn, err := claimcheck.ClaimCheckRoleARN("myapp", "prod", "cc-abc123", "rw")
+	arn, err := claimcheck.ClaimCheckRoleARN("billing", "test", "invoices", "rw")
 	require.NoError(t, err)
-	assert.Equal(t, "arn:aws:iam:::role/happi/myapp/prod/cc-abc123/myapp.prod.cc-abc123.rw", arn)
+	assert.Equal(t, "arn:aws:iam:::role/happi/billing/test/invoices/billing.test.invoices.rw", arn)
 }
 
 func TestClaimCheckRoleARN_RejectsEmptyArgs(t *testing.T) {

--- a/kafkarator/claimcheck/export_test.go
+++ b/kafkarator/claimcheck/export_test.go
@@ -38,25 +38,20 @@ type EnvelopeDeserializer = envelopeDeserializer
 type S3ReaderFactory = func(system, bucket string) (S3Reader, error)
 
 // ResolveForTest decodes the envelope and resolves a PayloadReader through the
-// full resolver path, using the given reader factory and default system name.
-// It returns the (system, bucket) the factory was asked to build a client for,
-// so tests can assert the issuer's system flows into the IAM role construction.
-// For use in tests only.
+// full resolver path, using the given reader factory. The (system, bucket) the
+// factory is asked to build a client for lets tests assert the issuer's system
+// flows into the IAM role construction. For use in tests only.
 func ResolveForTest(
 	factory S3ReaderFactory,
-	defaultSystem string,
 	de EnvelopeDeserializer,
 	topic string,
 	value []byte,
 ) error {
 	r := newResolver(
 		factory,
-		defaultSystem,
 		de,
 		nooptrace.NewTracerProvider().Tracer(""),
 		DefaultBucketResolver,
-		DefaultSystemResolver,
-		nil,
 	)
 	_, err := r.fetchPayload(context.Background(), topic, value)
 	return err
@@ -78,20 +73,11 @@ func NewMessage(
 		Headers: headers,
 		resolver: newResolver(
 			func(_, _ string) (S3Reader, error) { return s3, nil },
-			"",
 			de,
 			nooptrace.NewTracerProvider().Tracer(""),
 			DefaultBucketResolver,
-			DefaultSystemResolver,
-			nil,
 		),
 	}
-}
-
-// WithWriterSystemForTest stamps the producing system name onto each envelope.
-// For use in tests only.
-func WithWriterSystemForTest(system string) WriterOption {
-	return func(c *writerConfig) { c.stagerOpts = append(c.stagerOpts, withSystem(system)) }
 }
 
 // WithWriterS3FactoryForTest injects a (system, bucket) writer factory so tests

--- a/kafkarator/claimcheck/export_test.go
+++ b/kafkarator/claimcheck/export_test.go
@@ -2,6 +2,7 @@ package claimcheck
 
 import (
 	"bytes"
+	"context"
 
 	parquet "github.com/parquet-go/parquet-go"
 	nooptrace "go.opentelemetry.io/otel/trace/noop"
@@ -17,8 +18,41 @@ func ClaimCheckRoleARN(system, env, bucket, access string) (string, error) {
 	return claimCheckRoleARN(system, env, bucket, access)
 }
 
+// RoleARNForClient builds a production S3 client via the same path used by the
+// writer/processor and returns the role ARN it computed for the given bucket.
+// The token exchanger is constructed from env vars but no network call is made
+// at construction time. For e2e tests only.
+func RoleARNForClient(bucket, access, system, env string) (string, error) {
+	c, err := newS3Client(bucket, access, system, env, nil)
+	if err != nil {
+		return "", err
+	}
+	return c.(*s3Client).roleARN, nil
+}
+
 // EnvelopeDeserializer is re-exported for use in tests only.
 type EnvelopeDeserializer = envelopeDeserializer
+
+// S3ReaderFactory mirrors the per-(system,bucket) reader factory used on the
+// read path. For use in tests only.
+type S3ReaderFactory = func(system, bucket string) (S3Reader, error)
+
+// ResolveForTest decodes the envelope and resolves a PayloadReader through the
+// full resolver path, using the given reader factory and default system name.
+// It returns the (system, bucket) the factory was asked to build a client for,
+// so tests can assert the issuer's system flows into the IAM role construction.
+// For use in tests only.
+func ResolveForTest(
+	factory S3ReaderFactory,
+	defaultSystem string,
+	de EnvelopeDeserializer,
+	topic string,
+	value []byte,
+) error {
+	r := newResolver(factory, defaultSystem, de, nooptrace.NewTracerProvider().Tracer(""), DefaultBucketResolver)
+	_, err := r.fetchPayload(context.Background(), topic, value)
+	return err
+}
 
 // NewMessage constructs a Message with an embedded resolver. For use in tests
 // that exercise handler logic without a full [Processor] setup.
@@ -34,7 +68,13 @@ func NewMessage(
 		Key:      key,
 		value:    value,
 		Headers:  headers,
-		resolver: newResolver(s3, de, nooptrace.NewTracerProvider().Tracer(""), DefaultBucketResolver),
+		resolver: newResolver(
+			func(_, _ string) (S3Reader, error) { return s3, nil },
+			"",
+			de,
+			nooptrace.NewTracerProvider().Tracer(""),
+			DefaultBucketResolver,
+		),
 	}
 }
 
@@ -48,6 +88,13 @@ func NewTestWriter(kw kafkaWriter, ser serializer, opts ...WriterOption) *Writer
 	}
 	stager := newStagerWithFactory(cfg.s3Factory, cfg.fetcher, ser, cfg.stagerOpts...)
 	return &Writer{kw: kw, stager: stager}
+}
+
+// WithWriterSystemForTest sets the producing system name stamped onto envelopes.
+// In production this is taken from the connection config; tests use this to
+// exercise the system field. For use in tests only.
+func WithWriterSystemForTest(system string) WriterOption {
+	return func(c *writerConfig) { c.stagerOpts = append(c.stagerOpts, withSystem(system)) }
 }
 
 // NewBytesReaderAt wraps a byte slice in a *bytes.Reader which implements

--- a/kafkarator/claimcheck/export_test.go
+++ b/kafkarator/claimcheck/export_test.go
@@ -64,10 +64,10 @@ func NewMessage(
 	de EnvelopeDeserializer,
 ) *Message {
 	return &Message{
-		Topic:    topic,
-		Key:      key,
-		value:    value,
-		Headers:  headers,
+		Topic:   topic,
+		Key:     key,
+		value:   value,
+		Headers: headers,
 		resolver: newResolver(
 			func(_, _ string) (S3Reader, error) { return s3, nil },
 			"",
@@ -76,6 +76,12 @@ func NewMessage(
 			DefaultBucketResolver,
 		),
 	}
+}
+
+// WithWriterSystemForTest stamps the producing system name onto each envelope.
+// For use in tests only.
+func WithWriterSystemForTest(system string) WriterOption {
+	return func(c *writerConfig) { c.stagerOpts = append(c.stagerOpts, withSystem(system)) }
 }
 
 // NewTestWriter creates a Writer for use in tests, bypassing kafkarator.Connection.
@@ -88,13 +94,6 @@ func NewTestWriter(kw kafkaWriter, ser serializer, opts ...WriterOption) *Writer
 	}
 	stager := newStagerWithFactory(cfg.s3Factory, cfg.fetcher, ser, cfg.stagerOpts...)
 	return &Writer{kw: kw, stager: stager}
-}
-
-// WithWriterSystemForTest sets the producing system name stamped onto envelopes.
-// In production this is taken from the connection config; tests use this to
-// exercise the system field. For use in tests only.
-func WithWriterSystemForTest(system string) WriterOption {
-	return func(c *writerConfig) { c.stagerOpts = append(c.stagerOpts, withSystem(system)) }
 }
 
 // NewBytesReaderAt wraps a byte slice in a *bytes.Reader which implements

--- a/kafkarator/claimcheck/export_test.go
+++ b/kafkarator/claimcheck/export_test.go
@@ -49,7 +49,15 @@ func ResolveForTest(
 	topic string,
 	value []byte,
 ) error {
-	r := newResolver(factory, defaultSystem, de, nooptrace.NewTracerProvider().Tracer(""), DefaultBucketResolver)
+	r := newResolver(
+		factory,
+		defaultSystem,
+		de,
+		nooptrace.NewTracerProvider().Tracer(""),
+		DefaultBucketResolver,
+		DefaultSystemResolver,
+		nil,
+	)
 	_, err := r.fetchPayload(context.Background(), topic, value)
 	return err
 }
@@ -74,6 +82,8 @@ func NewMessage(
 			de,
 			nooptrace.NewTracerProvider().Tracer(""),
 			DefaultBucketResolver,
+			DefaultSystemResolver,
+			nil,
 		),
 	}
 }
@@ -82,6 +92,12 @@ func NewMessage(
 // For use in tests only.
 func WithWriterSystemForTest(system string) WriterOption {
 	return func(c *writerConfig) { c.stagerOpts = append(c.stagerOpts, withSystem(system)) }
+}
+
+// WithWriterS3FactoryForTest injects a (system, bucket) writer factory so tests
+// can assert which system the write client is built for. For use in tests only.
+func WithWriterS3FactoryForTest(fn func(system, bucket string) (S3Writer, error)) WriterOption {
+	return func(c *writerConfig) { c.s3Factory = fn }
 }
 
 // NewTestWriter creates a Writer for use in tests, bypassing kafkarator.Connection.

--- a/kafkarator/claimcheck/helpers_test.go
+++ b/kafkarator/claimcheck/helpers_test.go
@@ -41,7 +41,7 @@ func simpleSchema(fields ...string) string {
 
 // fakeEnvelopeDeserializer implements EnvelopeDeserializer for tests.
 type fakeEnvelopeDeserializer struct {
-	env *claimcheck.Envelope
+	envelope *claimcheck.Envelope
 }
 
 func (f *fakeEnvelopeDeserializer) DeserializeEnvelope(
@@ -49,7 +49,7 @@ func (f *fakeEnvelopeDeserializer) DeserializeEnvelope(
 	_ string,
 	_ []byte,
 ) (*claimcheck.Envelope, error) {
-	return f.env, nil
+	return f.envelope, nil
 }
 
 // captureKW records the last message written to Kafka.
@@ -84,9 +84,9 @@ func (j *jsonSerializer) Serialize(_ context.Context, _ string, value any) ([]by
 // unmarshalEnvelope decodes a JSON-serialized envelope captured from a test KafkaWriter.
 func unmarshalEnvelope(t *testing.T, data []byte) *claimcheck.Envelope {
 	t.Helper()
-	var env claimcheck.Envelope
-	require.NoError(t, json.Unmarshal(data, &env))
-	return &env
+	var envelope claimcheck.Envelope
+	require.NoError(t, json.Unmarshal(data, &envelope))
+	return &envelope
 }
 
 // bucketAndKey splits an s3://bucket/key URI into its two components.

--- a/kafkarator/claimcheck/message.go
+++ b/kafkarator/claimcheck/message.go
@@ -73,7 +73,7 @@ func Records[T any](ctx context.Context, m *Message) iter.Seq2[T, error] {
 		return func(yield func(T, error) bool) {}
 	}
 	return func(yield func(T, error) bool) {
-		env, err := m.PeekEnvelope(ctx)
+		envelope, err := m.PeekEnvelope(ctx)
 		if err != nil {
 			yield(zero, err)
 			return
@@ -82,15 +82,15 @@ func Records[T any](ctx context.Context, m *Message) iter.Seq2[T, error] {
 			trace.WithSpanKind(trace.SpanKindClient),
 			trace.WithAttributes(
 				attribute.String("messaging.destination.name", m.Topic),
-				attribute.String("claim_check.batch_id", env.BatchID),
-				attribute.Int64("claim_check.record_count", env.RecordCount),
-				attribute.Int64("claim_check.byte_size", env.ByteSize),
-				attribute.String("claim_check.storage_uri", env.StorageURI),
+				attribute.String("claim_check.batch_id", envelope.BatchID),
+				attribute.Int64("claim_check.record_count", envelope.RecordCount),
+				attribute.Int64("claim_check.byte_size", envelope.ByteSize),
+				attribute.String("claim_check.storage_uri", envelope.StorageURI),
 			),
 		)
 		defer span.End()
 
-		pr, err := m.resolver.fetchPayloadFromEnvelope(ctx, m.Topic, env)
+		pr, err := m.resolver.fetchPayloadFromEnvelope(ctx, m.Topic, envelope)
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())

--- a/kafkarator/claimcheck/message_test.go
+++ b/kafkarator/claimcheck/message_test.go
@@ -20,7 +20,14 @@ func TestPeekEnvelope_ReturnsMetadataWithoutFetchingPayload(t *testing.T) {
 		CreatedAt:   1_700_000_000_000,
 	}
 	s3 := claimcheck.NewFakeS3Client()
-	msg := claimcheck.NewMessage("peek-topic", nil, []byte("wire"), nil, s3, &fakeEnvelopeDeserializer{envelope: envelope})
+	msg := claimcheck.NewMessage(
+		"peek-topic",
+		nil,
+		[]byte("wire"),
+		nil,
+		s3,
+		&fakeEnvelopeDeserializer{envelope: envelope},
+	)
 
 	meta, err := msg.PeekEnvelope(context.Background())
 	require.NoError(t, err)
@@ -65,7 +72,14 @@ func TestMessage_Payload_RejectsTamperedBucket(t *testing.T) {
 		ByteSize:    100,
 	}
 	s3 := claimcheck.NewFakeS3Client()
-	msg := claimcheck.NewMessage("real-topic", nil, []byte("wire"), nil, s3, &fakeEnvelopeDeserializer{envelope: envelope})
+	msg := claimcheck.NewMessage(
+		"real-topic",
+		nil,
+		[]byte("wire"),
+		nil,
+		s3,
+		&fakeEnvelopeDeserializer{envelope: envelope},
+	)
 
 	_, err := msg.Payload(context.Background())
 	require.Error(t, err)
@@ -82,7 +96,14 @@ func TestMessage_Payload_RejectsTamperedKeyPrefix(t *testing.T) {
 		ByteSize:    100,
 	}
 	s3 := claimcheck.NewFakeS3Client()
-	msg := claimcheck.NewMessage("real-topic", nil, []byte("wire"), nil, s3, &fakeEnvelopeDeserializer{envelope: envelope})
+	msg := claimcheck.NewMessage(
+		"real-topic",
+		nil,
+		[]byte("wire"),
+		nil,
+		s3,
+		&fakeEnvelopeDeserializer{envelope: envelope},
+	)
 
 	_, err := msg.Payload(context.Background())
 	require.Error(t, err)

--- a/kafkarator/claimcheck/message_test.go
+++ b/kafkarator/claimcheck/message_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestPeekEnvelope_ReturnsMetadataWithoutFetchingPayload(t *testing.T) {
-	env := &claimcheck.Envelope{
+	envelope := &claimcheck.Envelope{
 		BatchID:     "batch-1",
 		StorageURI:  "s3://bucket/topic/batch-1.parquet",
 		Topic:       "peek-topic",
@@ -20,7 +20,7 @@ func TestPeekEnvelope_ReturnsMetadataWithoutFetchingPayload(t *testing.T) {
 		CreatedAt:   1_700_000_000_000,
 	}
 	s3 := claimcheck.NewFakeS3Client()
-	msg := claimcheck.NewMessage("peek-topic", nil, []byte("wire"), nil, s3, &fakeEnvelopeDeserializer{env: env})
+	msg := claimcheck.NewMessage("peek-topic", nil, []byte("wire"), nil, s3, &fakeEnvelopeDeserializer{envelope: envelope})
 
 	meta, err := msg.PeekEnvelope(context.Background())
 	require.NoError(t, err)
@@ -57,7 +57,7 @@ func TestMessage_Empty(t *testing.T) {
 }
 
 func TestMessage_Payload_RejectsTamperedBucket(t *testing.T) {
-	env := &claimcheck.Envelope{
+	envelope := &claimcheck.Envelope{
 		BatchID:     "batch-1",
 		StorageURI:  "s3://cc-wrongbucket/real-topic/batch-1.parquet",
 		Topic:       "real-topic",
@@ -65,7 +65,7 @@ func TestMessage_Payload_RejectsTamperedBucket(t *testing.T) {
 		ByteSize:    100,
 	}
 	s3 := claimcheck.NewFakeS3Client()
-	msg := claimcheck.NewMessage("real-topic", nil, []byte("wire"), nil, s3, &fakeEnvelopeDeserializer{env: env})
+	msg := claimcheck.NewMessage("real-topic", nil, []byte("wire"), nil, s3, &fakeEnvelopeDeserializer{envelope: envelope})
 
 	_, err := msg.Payload(context.Background())
 	require.Error(t, err)
@@ -74,7 +74,7 @@ func TestMessage_Payload_RejectsTamperedBucket(t *testing.T) {
 
 func TestMessage_Payload_RejectsTamperedKeyPrefix(t *testing.T) {
 	correctBucket := claimcheck.DefaultBucketResolver("real-topic")
-	env := &claimcheck.Envelope{
+	envelope := &claimcheck.Envelope{
 		BatchID:     "batch-1",
 		StorageURI:  "s3://" + correctBucket + "/other-topic/batch-1.parquet",
 		Topic:       "real-topic",
@@ -82,7 +82,7 @@ func TestMessage_Payload_RejectsTamperedKeyPrefix(t *testing.T) {
 		ByteSize:    100,
 	}
 	s3 := claimcheck.NewFakeS3Client()
-	msg := claimcheck.NewMessage("real-topic", nil, []byte("wire"), nil, s3, &fakeEnvelopeDeserializer{env: env})
+	msg := claimcheck.NewMessage("real-topic", nil, []byte("wire"), nil, s3, &fakeEnvelopeDeserializer{envelope: envelope})
 
 	_, err := msg.Payload(context.Background())
 	require.Error(t, err)

--- a/kafkarator/claimcheck/processor.go
+++ b/kafkarator/claimcheck/processor.go
@@ -104,18 +104,27 @@ func NewProcessor(
 		o(cfg)
 	}
 
-	s3Reader := cfg.s3
 	bucketResolver := cfg.bucketResolver
 	if bucketResolver == nil {
 		bucketResolver = DefaultBucketResolver
 	}
-	if s3Reader == nil {
-		var err error
-		connCfg := conn.Config()
-		s3Reader, err = defaultS3ReaderFor(bucketResolver(topic), connCfg.SystemName, connCfg.Env)
+
+	connCfg := conn.Config()
+
+	// The S3 reader is resolved per-envelope, keyed by the producing system named
+	// in the envelope, because the bucket is owned by that system and the assumed
+	// IAM role must be scoped to it. defaultSystem is the consumer's own system,
+	// used as a fallback for legacy envelopes that predate the system field.
+	var s3Factory s3ReaderFactory
+	if cfg.s3 != nil {
+		fixed := cfg.s3
+		s3Factory = func(_, _ string) (S3Reader, error) { return fixed, nil }
+	} else {
+		exchanger, err := newTokenExchanger()
 		if err != nil {
-			return nil, fmt.Errorf("claimcheck: create S3 reader: %w", err)
+			return nil, fmt.Errorf("claimcheck: init token exchanger: %w", err)
 		}
+		s3Factory = defaultS3ReaderFactory(exchanger, connCfg.Env)
 	}
 
 	tracer := cfg.tracer
@@ -123,7 +132,7 @@ func NewProcessor(
 		tracer = conn.Tracer()
 	}
 
-	res := newResolver(s3Reader, &avroDeserializer{de: conn.Deserializer()}, tracer, bucketResolver)
+	res := newResolver(s3Factory, connCfg.SystemName, &avroDeserializer{de: conn.Deserializer()}, tracer, bucketResolver)
 
 	// Default to maxMessages=1 — each envelope is a heavyweight S3 fetch.
 	kafkaOpts := append(

--- a/kafkarator/claimcheck/processor.go
+++ b/kafkarator/claimcheck/processor.go
@@ -132,7 +132,13 @@ func NewProcessor(
 		tracer = conn.Tracer()
 	}
 
-	res := newResolver(s3Factory, connCfg.SystemName, &avroDeserializer{de: conn.Deserializer()}, tracer, bucketResolver)
+	res := newResolver(
+		s3Factory,
+		connCfg.SystemName,
+		&avroDeserializer{de: conn.Deserializer()},
+		tracer,
+		bucketResolver,
+	)
 
 	// Default to maxMessages=1 — each envelope is a heavyweight S3 fetch.
 	kafkaOpts := append(

--- a/kafkarator/claimcheck/processor.go
+++ b/kafkarator/claimcheck/processor.go
@@ -34,6 +34,7 @@ type ProcessorOption func(*processorConfig)
 type processorConfig struct {
 	s3             S3Reader
 	bucketResolver BucketResolver
+	systemResolver SystemResolver
 	tracer         trace.Tracer
 	kafkaOpts      []kafkarator.ProcessorOption
 }
@@ -51,6 +52,13 @@ func WithProcessorS3Client(s3 S3Reader) ProcessorOption {
 // used on the corresponding writer; mismatches result in the wrong IAM role being assumed.
 func WithProcessorBucketResolver(fn BucketResolver) ProcessorOption {
 	return func(c *processorConfig) { c.bucketResolver = fn }
+}
+
+// WithProcessorSystemResolver overrides the default topic→system derivation used
+// as the legacy fallback when an envelope carries no system. Must match the
+// resolver used on the corresponding writer.
+func WithProcessorSystemResolver(fn SystemResolver) ProcessorOption {
+	return func(c *processorConfig) { c.systemResolver = fn }
 }
 
 // WithProcessorMaxMessages sets the maximum number of Kafka messages received
@@ -109,6 +117,11 @@ func NewProcessor(
 		bucketResolver = DefaultBucketResolver
 	}
 
+	systemResolver := cfg.systemResolver
+	if systemResolver == nil {
+		systemResolver = DefaultSystemResolver
+	}
+
 	connCfg := conn.Config()
 
 	// The S3 reader is resolved per-envelope, keyed by the producing system named
@@ -138,6 +151,8 @@ func NewProcessor(
 		&avroDeserializer{de: conn.Deserializer()},
 		tracer,
 		bucketResolver,
+		systemResolver,
+		conn.Logger(),
 	)
 
 	// Default to maxMessages=1 — each envelope is a heavyweight S3 fetch.

--- a/kafkarator/claimcheck/processor.go
+++ b/kafkarator/claimcheck/processor.go
@@ -34,7 +34,6 @@ type ProcessorOption func(*processorConfig)
 type processorConfig struct {
 	s3             S3Reader
 	bucketResolver BucketResolver
-	systemResolver SystemResolver
 	tracer         trace.Tracer
 	kafkaOpts      []kafkarator.ProcessorOption
 }
@@ -52,13 +51,6 @@ func WithProcessorS3Client(s3 S3Reader) ProcessorOption {
 // used on the corresponding writer; mismatches result in the wrong IAM role being assumed.
 func WithProcessorBucketResolver(fn BucketResolver) ProcessorOption {
 	return func(c *processorConfig) { c.bucketResolver = fn }
-}
-
-// WithProcessorSystemResolver overrides the default topic→system derivation used
-// as the legacy fallback when an envelope carries no system. Must match the
-// resolver used on the corresponding writer.
-func WithProcessorSystemResolver(fn SystemResolver) ProcessorOption {
-	return func(c *processorConfig) { c.systemResolver = fn }
 }
 
 // WithProcessorMaxMessages sets the maximum number of Kafka messages received
@@ -117,17 +109,12 @@ func NewProcessor(
 		bucketResolver = DefaultBucketResolver
 	}
 
-	systemResolver := cfg.systemResolver
-	if systemResolver == nil {
-		systemResolver = DefaultSystemResolver
-	}
-
 	connCfg := conn.Config()
 
 	// The S3 reader is resolved per-envelope, keyed by the producing system named
 	// in the envelope, because the bucket is owned by that system and the assumed
-	// IAM role must be scoped to it. defaultSystem is the consumer's own system,
-	// used as a fallback for legacy envelopes that predate the system field.
+	// IAM role must be scoped to it. The system is stamped by the writer (derived
+	// from the topic) and is required; envelopes without one are rejected.
 	var s3Factory s3ReaderFactory
 	if cfg.s3 != nil {
 		fixed := cfg.s3
@@ -147,12 +134,9 @@ func NewProcessor(
 
 	res := newResolver(
 		s3Factory,
-		connCfg.SystemName,
 		&avroDeserializer{de: conn.Deserializer()},
 		tracer,
 		bucketResolver,
-		systemResolver,
-		conn.Logger(),
 	)
 
 	// Default to maxMessages=1 — each envelope is a heavyweight S3 fetch.

--- a/kafkarator/claimcheck/processor.go
+++ b/kafkarator/claimcheck/processor.go
@@ -202,9 +202,9 @@ type avroDeserializer struct {
 }
 
 func (a *avroDeserializer) DeserializeEnvelope(ctx context.Context, topic string, data []byte) (*Envelope, error) {
-	var env Envelope
-	if err := a.de.Deserialize(ctx, topic, data, &env); err != nil {
+	var envelope Envelope
+	if err := a.de.Deserialize(ctx, topic, data, &envelope); err != nil {
 		return nil, fmt.Errorf("claimcheck: deserialize envelope: %w", err)
 	}
-	return &env, nil
+	return &envelope, nil
 }

--- a/kafkarator/claimcheck/resolver.go
+++ b/kafkarator/claimcheck/resolver.go
@@ -78,7 +78,11 @@ func (r *resolver) fetchPayload(ctx context.Context, topic string, data []byte) 
 	return r.fetchPayloadFromEnvelope(ctx, topic, envelope)
 }
 
-func (r *resolver) fetchPayloadFromEnvelope(ctx context.Context, topic string, envelope *Envelope) (*PayloadReader, error) {
+func (r *resolver) fetchPayloadFromEnvelope(
+	ctx context.Context,
+	topic string,
+	envelope *Envelope,
+) (*PayloadReader, error) {
 	bucket, key, err := s3URIParts(envelope.StorageURI)
 	if err != nil {
 		return nil, err

--- a/kafkarator/claimcheck/resolver.go
+++ b/kafkarator/claimcheck/resolver.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"strings"
 
 	"go.opentelemetry.io/otel/trace"
@@ -28,6 +29,8 @@ type resolver struct {
 	deserializer   envelopeDeserializer
 	tracer         trace.Tracer
 	bucketResolver BucketResolver
+	systemResolver SystemResolver
+	logger         *slog.Logger
 }
 
 func newResolver(
@@ -36,9 +39,17 @@ func newResolver(
 	deserializer envelopeDeserializer,
 	tracer trace.Tracer,
 	bucketResolver BucketResolver,
+	systemResolver SystemResolver,
+	logger *slog.Logger,
 ) *resolver {
 	if bucketResolver == nil {
 		bucketResolver = DefaultBucketResolver
+	}
+	if systemResolver == nil {
+		systemResolver = DefaultSystemResolver
+	}
+	if logger == nil {
+		logger = slog.Default()
 	}
 	return &resolver{
 		s3Factory:      s3Factory,
@@ -46,6 +57,8 @@ func newResolver(
 		deserializer:   deserializer,
 		tracer:         tracer,
 		bucketResolver: bucketResolver,
+		systemResolver: systemResolver,
+		logger:         logger,
 	}
 }
 
@@ -86,12 +99,28 @@ func (r *resolver) fetchPayloadFromEnvelope(ctx context.Context, topic string, e
 			topic,
 		)
 	}
-	// The bucket is owned by the producing system named in the envelope; assume
-	// that system's role. Legacy envelopes without a system fall back to the
-	// consumer's own system.
+	// Happy path: trust the producing system stamped in the envelope. For legacy
+	// envelopes without a system, derive the owner from the topic (correct even
+	// for shared products), falling back to the consumer's own system only for
+	// non-conventional topics. If a stamped system and a topic-derived system both
+	// exist and disagree, the stamp is authoritative (it may be a deliberate
+	// override) but we log a warning.
 	system := env.System
-	if system == "" {
-		system = r.defaultSystem
+	derived := r.systemResolver(topic)
+	switch {
+	case system == "":
+		if derived != "" {
+			system = derived
+		} else {
+			system = r.defaultSystem
+		}
+	case derived != "" && derived != system:
+		r.logger.WarnContext(ctx,
+			"claimcheck: envelope system disagrees with topic-derived system; trusting envelope",
+			"envelope-system", system,
+			"derived-system", derived,
+			"topic", topic,
+		)
 	}
 	s3, err := r.s3Factory(system, bucket)
 	if err != nil {

--- a/kafkarator/claimcheck/resolver.go
+++ b/kafkarator/claimcheck/resolver.go
@@ -15,16 +15,24 @@ type envelopeDeserializer interface {
 	DeserializeEnvelope(ctx context.Context, topic string, data []byte) (*Envelope, error)
 }
 
+// s3ReaderFactory builds an S3Reader scoped to a producing system and bucket.
+// The system determines which Ceph IAM role is assumed, so it must be the
+// system that owns the bucket (the producer named in the envelope), not the
+// consumer's own system.
+type s3ReaderFactory func(system, bucket string) (S3Reader, error)
+
 // resolver decodes claim-check envelopes and fetches payloads from S3.
 type resolver struct {
-	s3             S3Reader
+	s3Factory      s3ReaderFactory
+	defaultSystem  string
 	deserializer   envelopeDeserializer
 	tracer         trace.Tracer
 	bucketResolver BucketResolver
 }
 
 func newResolver(
-	s3 S3Reader,
+	s3Factory s3ReaderFactory,
+	defaultSystem string,
 	deserializer envelopeDeserializer,
 	tracer trace.Tracer,
 	bucketResolver BucketResolver,
@@ -32,7 +40,13 @@ func newResolver(
 	if bucketResolver == nil {
 		bucketResolver = DefaultBucketResolver
 	}
-	return &resolver{s3: s3, deserializer: deserializer, tracer: tracer, bucketResolver: bucketResolver}
+	return &resolver{
+		s3Factory:      s3Factory,
+		defaultSystem:  defaultSystem,
+		deserializer:   deserializer,
+		tracer:         tracer,
+		bucketResolver: bucketResolver,
+	}
 }
 
 func (r *resolver) peekEnvelope(ctx context.Context, topic string, data []byte) (*Envelope, error) {
@@ -72,7 +86,18 @@ func (r *resolver) fetchPayloadFromEnvelope(ctx context.Context, topic string, e
 			topic,
 		)
 	}
-	return &PayloadReader{ctx: ctx, s3: r.s3, bucket: bucket, key: key, size: env.ByteSize}, nil
+	// The bucket is owned by the producing system named in the envelope; assume
+	// that system's role. Legacy envelopes without a system fall back to the
+	// consumer's own system.
+	system := env.System
+	if system == "" {
+		system = r.defaultSystem
+	}
+	s3, err := r.s3Factory(system, bucket)
+	if err != nil {
+		return nil, fmt.Errorf("claimcheck: create S3 reader for system %q bucket %q: %w", system, bucket, err)
+	}
+	return &PayloadReader{ctx: ctx, s3: s3, bucket: bucket, key: key, size: env.ByteSize}, nil
 }
 
 // PayloadReader provides read access to the raw Parquet bytes of a

--- a/kafkarator/claimcheck/resolver.go
+++ b/kafkarator/claimcheck/resolver.go
@@ -63,23 +63,23 @@ func newResolver(
 }
 
 func (r *resolver) peekEnvelope(ctx context.Context, topic string, data []byte) (*Envelope, error) {
-	env, err := r.deserializer.DeserializeEnvelope(ctx, topic, data)
+	envelope, err := r.deserializer.DeserializeEnvelope(ctx, topic, data)
 	if err != nil {
 		return nil, fmt.Errorf("claimcheck: peek envelope: %w", err)
 	}
-	return env, nil
+	return envelope, nil
 }
 
 func (r *resolver) fetchPayload(ctx context.Context, topic string, data []byte) (*PayloadReader, error) {
-	env, err := r.deserializer.DeserializeEnvelope(ctx, topic, data)
+	envelope, err := r.deserializer.DeserializeEnvelope(ctx, topic, data)
 	if err != nil {
 		return nil, fmt.Errorf("claimcheck: fetch payload: %w", err)
 	}
-	return r.fetchPayloadFromEnvelope(ctx, topic, env)
+	return r.fetchPayloadFromEnvelope(ctx, topic, envelope)
 }
 
-func (r *resolver) fetchPayloadFromEnvelope(ctx context.Context, topic string, env *Envelope) (*PayloadReader, error) {
-	bucket, key, err := s3URIParts(env.StorageURI)
+func (r *resolver) fetchPayloadFromEnvelope(ctx context.Context, topic string, envelope *Envelope) (*PayloadReader, error) {
+	bucket, key, err := s3URIParts(envelope.StorageURI)
 	if err != nil {
 		return nil, err
 	}
@@ -105,7 +105,7 @@ func (r *resolver) fetchPayloadFromEnvelope(ctx context.Context, topic string, e
 	// non-conventional topics. If a stamped system and a topic-derived system both
 	// exist and disagree, the stamp is authoritative (it may be a deliberate
 	// override) but we log a warning.
-	system := env.System
+	system := envelope.System
 	derived := r.systemResolver(topic)
 	switch {
 	case system == "":
@@ -126,7 +126,7 @@ func (r *resolver) fetchPayloadFromEnvelope(ctx context.Context, topic string, e
 	if err != nil {
 		return nil, fmt.Errorf("claimcheck: create S3 reader for system %q bucket %q: %w", system, bucket, err)
 	}
-	return &PayloadReader{ctx: ctx, s3: s3, bucket: bucket, key: key, size: env.ByteSize}, nil
+	return &PayloadReader{ctx: ctx, s3: s3, bucket: bucket, key: key, size: envelope.ByteSize}, nil
 }
 
 // PayloadReader provides read access to the raw Parquet bytes of a

--- a/kafkarator/claimcheck/resolver.go
+++ b/kafkarator/claimcheck/resolver.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log/slog"
 	"strings"
 
 	"go.opentelemetry.io/otel/trace"
@@ -25,40 +24,25 @@ type s3ReaderFactory func(system, bucket string) (S3Reader, error)
 // resolver decodes claim-check envelopes and fetches payloads from S3.
 type resolver struct {
 	s3Factory      s3ReaderFactory
-	defaultSystem  string
 	deserializer   envelopeDeserializer
 	tracer         trace.Tracer
 	bucketResolver BucketResolver
-	systemResolver SystemResolver
-	logger         *slog.Logger
 }
 
 func newResolver(
 	s3Factory s3ReaderFactory,
-	defaultSystem string,
 	deserializer envelopeDeserializer,
 	tracer trace.Tracer,
 	bucketResolver BucketResolver,
-	systemResolver SystemResolver,
-	logger *slog.Logger,
 ) *resolver {
 	if bucketResolver == nil {
 		bucketResolver = DefaultBucketResolver
 	}
-	if systemResolver == nil {
-		systemResolver = DefaultSystemResolver
-	}
-	if logger == nil {
-		logger = slog.Default()
-	}
 	return &resolver{
 		s3Factory:      s3Factory,
-		defaultSystem:  defaultSystem,
 		deserializer:   deserializer,
 		tracer:         tracer,
 		bucketResolver: bucketResolver,
-		systemResolver: systemResolver,
-		logger:         logger,
 	}
 }
 
@@ -103,27 +87,15 @@ func (r *resolver) fetchPayloadFromEnvelope(
 			topic,
 		)
 	}
-	// Happy path: trust the producing system stamped in the envelope. For legacy
-	// envelopes without a system, derive the owner from the topic (correct even
-	// for shared products), falling back to the consumer's own system only for
-	// non-conventional topics. If a stamped system and a topic-derived system both
-	// exist and disagree, the stamp is authoritative (it may be a deliberate
-	// override) but we log a warning.
+	// The producing system is stamped on the envelope by the writer (derived from
+	// the topic, never overridable). It identifies the bucket owner whose Ceph IAM
+	// role must be assumed to read the payload. It must always be set; an empty
+	// system means a malformed or pre-system-field envelope we cannot resolve.
 	system := envelope.System
-	derived := r.systemResolver(topic)
-	switch {
-	case system == "":
-		if derived != "" {
-			system = derived
-		} else {
-			system = r.defaultSystem
-		}
-	case derived != "" && derived != system:
-		r.logger.WarnContext(ctx,
-			"claimcheck: envelope system disagrees with topic-derived system; trusting envelope",
-			"envelope-system", system,
-			"derived-system", derived,
-			"topic", topic,
+	if system == "" {
+		return nil, fmt.Errorf(
+			"claimcheck: envelope for topic %q has no system; cannot determine the bucket owner whose role must be assumed",
+			topic,
 		)
 	}
 	s3, err := r.s3Factory(system, bucket)

--- a/kafkarator/claimcheck/resolver_system_test.go
+++ b/kafkarator/claimcheck/resolver_system_test.go
@@ -1,0 +1,63 @@
+package claimcheck_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hafslundkraft/golib/kafkarator/claimcheck"
+)
+
+// envelopeForTopic builds an envelope whose StorageURI points at the
+// convention-derived bucket for topic, with the given producer system name.
+func envelopeForTopic(topic, system string) *claimcheck.Envelope {
+	bucket := claimcheck.DefaultBucketResolver(topic)
+	return &claimcheck.Envelope{
+		BatchID:     "batch-1",
+		StorageURI:  "s3://" + bucket + "/" + topic + "/batch-1.parquet",
+		Topic:       topic,
+		RecordCount: 1,
+		ByteSize:    1,
+		System:      system,
+	}
+}
+
+// TestResolver_UsesEnvelopeSystem verifies that when an envelope carries a
+// producer system name, the reader builds its S3 client (and thus its IAM role
+// ARN) for that issuer system — not the consumer's own system.
+func TestResolver_UsesEnvelopeSystem(t *testing.T) {
+	const topic = "billing.test.invoices"
+	env := envelopeForTopic(topic, "billing") // produced by "billing"
+
+	var gotSystem, gotBucket string
+	factory := func(system, bucket string) (claimcheck.S3Reader, error) {
+		gotSystem, gotBucket = system, bucket
+		return claimcheck.NewFakeS3Client(), nil
+	}
+
+	// Consumer's own system is "analytics" — must be ignored in favour of the issuer.
+	err := claimcheck.ResolveForTest(factory, "analytics", &fakeEnvelopeDeserializer{env: env}, topic, []byte("wire"))
+	require.NoError(t, err)
+
+	assert.Equal(t, "billing", gotSystem, "reader must assume the producer's role, not the consumer's")
+	assert.Equal(t, claimcheck.DefaultBucketResolver(topic), gotBucket)
+}
+
+// TestResolver_FallsBackToDefaultSystem verifies that legacy envelopes without a
+// system field fall back to the consumer's own system name.
+func TestResolver_FallsBackToDefaultSystem(t *testing.T) {
+	const topic = "billing.test.invoices"
+	env := envelopeForTopic(topic, "") // legacy envelope, no system
+
+	var gotSystem string
+	factory := func(system, _ string) (claimcheck.S3Reader, error) {
+		gotSystem = system
+		return claimcheck.NewFakeS3Client(), nil
+	}
+
+	err := claimcheck.ResolveForTest(factory, "analytics", &fakeEnvelopeDeserializer{env: env}, topic, []byte("wire"))
+	require.NoError(t, err)
+
+	assert.Equal(t, "analytics", gotSystem, "missing system must fall back to the consumer's own system")
+}

--- a/kafkarator/claimcheck/resolver_system_test.go
+++ b/kafkarator/claimcheck/resolver_system_test.go
@@ -37,7 +37,13 @@ func TestResolver_UsesEnvelopeSystem(t *testing.T) {
 	}
 
 	// Consumer's own system is "analytics" — must be ignored in favor of the issuer.
-	err := claimcheck.ResolveForTest(factory, "analytics", &fakeEnvelopeDeserializer{envelope: envelope}, topic, []byte("wire"))
+	err := claimcheck.ResolveForTest(
+		factory,
+		"analytics",
+		&fakeEnvelopeDeserializer{envelope: envelope},
+		topic,
+		[]byte("wire"),
+	)
 	require.NoError(t, err)
 
 	assert.Equal(t, "billing", gotSystem, "reader must assume the producer's role, not the consumer's")
@@ -56,7 +62,13 @@ func TestResolver_FallsBackToDefaultSystem(t *testing.T) {
 		return claimcheck.NewFakeS3Client(), nil
 	}
 
-	err := claimcheck.ResolveForTest(factory, "analytics", &fakeEnvelopeDeserializer{envelope: envelope}, topic, []byte("wire"))
+	err := claimcheck.ResolveForTest(
+		factory,
+		"analytics",
+		&fakeEnvelopeDeserializer{envelope: envelope},
+		topic,
+		[]byte("wire"),
+	)
 	require.NoError(t, err)
 
 	assert.Equal(t, "analytics", gotSystem, "missing system must fall back to the consumer's own system")
@@ -67,7 +79,7 @@ func TestResolver_FallsBackToDefaultSystem(t *testing.T) {
 // via topic-derivation, NOT to the consumer's own system.
 func TestResolver_LegacyEnvelopeDerivesSharedSystemFromTopic(t *testing.T) {
 	const topic = "test.water--obs.measurements--v1" // shared product
-	envelope := envelopeForTopic(topic, "")               // legacy: no system
+	envelope := envelopeForTopic(topic, "")          // legacy: no system
 
 	var gotSystem string
 	factory := func(system, _ string) (claimcheck.S3Reader, error) {
@@ -75,7 +87,13 @@ func TestResolver_LegacyEnvelopeDerivesSharedSystemFromTopic(t *testing.T) {
 		return claimcheck.NewFakeS3Client(), nil
 	}
 
-	err := claimcheck.ResolveForTest(factory, "analytics", &fakeEnvelopeDeserializer{envelope: envelope}, topic, []byte("wire"))
+	err := claimcheck.ResolveForTest(
+		factory,
+		"analytics",
+		&fakeEnvelopeDeserializer{envelope: envelope},
+		topic,
+		[]byte("wire"),
+	)
 	require.NoError(t, err)
 
 	assert.Equal(t, "data-definitions", gotSystem,
@@ -95,7 +113,13 @@ func TestResolver_LegacyEnvelopeNonConventionalTopicFallsBack(t *testing.T) {
 		return claimcheck.NewFakeS3Client(), nil
 	}
 
-	err := claimcheck.ResolveForTest(factory, "analytics", &fakeEnvelopeDeserializer{envelope: envelope}, topic, []byte("wire"))
+	err := claimcheck.ResolveForTest(
+		factory,
+		"analytics",
+		&fakeEnvelopeDeserializer{envelope: envelope},
+		topic,
+		[]byte("wire"),
+	)
 	require.NoError(t, err)
 
 	assert.Equal(t, "analytics", gotSystem)

--- a/kafkarator/claimcheck/resolver_system_test.go
+++ b/kafkarator/claimcheck/resolver_system_test.go
@@ -61,3 +61,42 @@ func TestResolver_FallsBackToDefaultSystem(t *testing.T) {
 
 	assert.Equal(t, "analytics", gotSystem, "missing system must fall back to the consumer's own system")
 }
+
+// TestResolver_LegacyEnvelopeDerivesSharedSystemFromTopic verifies that a legacy
+// envelope (System == "") on a shared-product topic resolves to data-definitions
+// via topic-derivation, NOT to the consumer's own system.
+func TestResolver_LegacyEnvelopeDerivesSharedSystemFromTopic(t *testing.T) {
+	const topic = "test.water--obs.measurements--v1" // shared product
+	env := envelopeForTopic(topic, "")               // legacy: no system
+
+	var gotSystem string
+	factory := func(system, _ string) (claimcheck.S3Reader, error) {
+		gotSystem = system
+		return claimcheck.NewFakeS3Client(), nil
+	}
+
+	err := claimcheck.ResolveForTest(factory, "analytics", &fakeEnvelopeDeserializer{env: env}, topic, []byte("wire"))
+	require.NoError(t, err)
+
+	assert.Equal(t, "data-definitions", gotSystem,
+		"legacy envelope on a shared topic must derive data-definitions, not the consumer's system")
+}
+
+// TestResolver_LegacyEnvelopeNonConventionalTopicFallsBack verifies that a legacy
+// envelope on a non-conventional topic (resolver returns "") still falls back to
+// the consumer's own system.
+func TestResolver_LegacyEnvelopeNonConventionalTopicFallsBack(t *testing.T) {
+	const topic = "billing.test.invoices" // no "--" in domain segment -> resolver ""
+	env := envelopeForTopic(topic, "")
+
+	var gotSystem string
+	factory := func(system, _ string) (claimcheck.S3Reader, error) {
+		gotSystem = system
+		return claimcheck.NewFakeS3Client(), nil
+	}
+
+	err := claimcheck.ResolveForTest(factory, "analytics", &fakeEnvelopeDeserializer{env: env}, topic, []byte("wire"))
+	require.NoError(t, err)
+
+	assert.Equal(t, "analytics", gotSystem)
+}

--- a/kafkarator/claimcheck/resolver_system_test.go
+++ b/kafkarator/claimcheck/resolver_system_test.go
@@ -28,7 +28,7 @@ func envelopeForTopic(topic, system string) *claimcheck.Envelope {
 // ARN) for that issuer system — not the consumer's own system.
 func TestResolver_UsesEnvelopeSystem(t *testing.T) {
 	const topic = "billing.test.invoices"
-	env := envelopeForTopic(topic, "billing") // produced by "billing"
+	envelope := envelopeForTopic(topic, "billing") // produced by "billing"
 
 	var gotSystem, gotBucket string
 	factory := func(system, bucket string) (claimcheck.S3Reader, error) {
@@ -37,7 +37,7 @@ func TestResolver_UsesEnvelopeSystem(t *testing.T) {
 	}
 
 	// Consumer's own system is "analytics" — must be ignored in favor of the issuer.
-	err := claimcheck.ResolveForTest(factory, "analytics", &fakeEnvelopeDeserializer{env: env}, topic, []byte("wire"))
+	err := claimcheck.ResolveForTest(factory, "analytics", &fakeEnvelopeDeserializer{envelope: envelope}, topic, []byte("wire"))
 	require.NoError(t, err)
 
 	assert.Equal(t, "billing", gotSystem, "reader must assume the producer's role, not the consumer's")
@@ -48,7 +48,7 @@ func TestResolver_UsesEnvelopeSystem(t *testing.T) {
 // system field fall back to the consumer's own system name.
 func TestResolver_FallsBackToDefaultSystem(t *testing.T) {
 	const topic = "billing.test.invoices"
-	env := envelopeForTopic(topic, "") // legacy envelope, no system
+	envelope := envelopeForTopic(topic, "") // legacy envelope, no system
 
 	var gotSystem string
 	factory := func(system, _ string) (claimcheck.S3Reader, error) {
@@ -56,7 +56,7 @@ func TestResolver_FallsBackToDefaultSystem(t *testing.T) {
 		return claimcheck.NewFakeS3Client(), nil
 	}
 
-	err := claimcheck.ResolveForTest(factory, "analytics", &fakeEnvelopeDeserializer{env: env}, topic, []byte("wire"))
+	err := claimcheck.ResolveForTest(factory, "analytics", &fakeEnvelopeDeserializer{envelope: envelope}, topic, []byte("wire"))
 	require.NoError(t, err)
 
 	assert.Equal(t, "analytics", gotSystem, "missing system must fall back to the consumer's own system")
@@ -67,7 +67,7 @@ func TestResolver_FallsBackToDefaultSystem(t *testing.T) {
 // via topic-derivation, NOT to the consumer's own system.
 func TestResolver_LegacyEnvelopeDerivesSharedSystemFromTopic(t *testing.T) {
 	const topic = "test.water--obs.measurements--v1" // shared product
-	env := envelopeForTopic(topic, "")               // legacy: no system
+	envelope := envelopeForTopic(topic, "")               // legacy: no system
 
 	var gotSystem string
 	factory := func(system, _ string) (claimcheck.S3Reader, error) {
@@ -75,7 +75,7 @@ func TestResolver_LegacyEnvelopeDerivesSharedSystemFromTopic(t *testing.T) {
 		return claimcheck.NewFakeS3Client(), nil
 	}
 
-	err := claimcheck.ResolveForTest(factory, "analytics", &fakeEnvelopeDeserializer{env: env}, topic, []byte("wire"))
+	err := claimcheck.ResolveForTest(factory, "analytics", &fakeEnvelopeDeserializer{envelope: envelope}, topic, []byte("wire"))
 	require.NoError(t, err)
 
 	assert.Equal(t, "data-definitions", gotSystem,
@@ -87,7 +87,7 @@ func TestResolver_LegacyEnvelopeDerivesSharedSystemFromTopic(t *testing.T) {
 // the consumer's own system.
 func TestResolver_LegacyEnvelopeNonConventionalTopicFallsBack(t *testing.T) {
 	const topic = "billing.test.invoices" // no "--" in domain segment -> resolver ""
-	env := envelopeForTopic(topic, "")
+	envelope := envelopeForTopic(topic, "")
 
 	var gotSystem string
 	factory := func(system, _ string) (claimcheck.S3Reader, error) {
@@ -95,7 +95,7 @@ func TestResolver_LegacyEnvelopeNonConventionalTopicFallsBack(t *testing.T) {
 		return claimcheck.NewFakeS3Client(), nil
 	}
 
-	err := claimcheck.ResolveForTest(factory, "analytics", &fakeEnvelopeDeserializer{env: env}, topic, []byte("wire"))
+	err := claimcheck.ResolveForTest(factory, "analytics", &fakeEnvelopeDeserializer{envelope: envelope}, topic, []byte("wire"))
 	require.NoError(t, err)
 
 	assert.Equal(t, "analytics", gotSystem)

--- a/kafkarator/claimcheck/resolver_system_test.go
+++ b/kafkarator/claimcheck/resolver_system_test.go
@@ -36,7 +36,7 @@ func TestResolver_UsesEnvelopeSystem(t *testing.T) {
 		return claimcheck.NewFakeS3Client(), nil
 	}
 
-	// Consumer's own system is "analytics" — must be ignored in favour of the issuer.
+	// Consumer's own system is "analytics" — must be ignored in favor of the issuer.
 	err := claimcheck.ResolveForTest(factory, "analytics", &fakeEnvelopeDeserializer{env: env}, topic, []byte("wire"))
 	require.NoError(t, err)
 

--- a/kafkarator/claimcheck/resolver_system_test.go
+++ b/kafkarator/claimcheck/resolver_system_test.go
@@ -23,104 +23,71 @@ func envelopeForTopic(topic, system string) *claimcheck.Envelope {
 	}
 }
 
-// TestResolver_UsesEnvelopeSystem verifies that when an envelope carries a
-// producer system name, the reader builds its S3 client (and thus its IAM role
-// ARN) for that issuer system — not the consumer's own system.
+// TestResolver_UsesEnvelopeSystem verifies that the reader builds its S3 client
+// (and thus its IAM role ARN) for the system stamped on the envelope, which the
+// writer derived from the topic — that is the bucket owner whose role must be
+// assumed. It covers both an internal product (sys--<system>) and a shared
+// product (<domain>--<sub>, owned by data-definitions).
 func TestResolver_UsesEnvelopeSystem(t *testing.T) {
-	const topic = "billing.test.invoices"
-	envelope := envelopeForTopic(topic, "billing") // produced by "billing"
+	for _, tc := range []struct {
+		name   string
+		topic  string
+		system string
+	}{
+		{"internal product", "test.sys--billing.invoices--v1", "billing"},
+		{"shared product (data-definitions)", "test.water--obs.measurements--v1", "data-definitions"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			envelope := envelopeForTopic(tc.topic, tc.system)
 
-	var gotSystem, gotBucket string
-	factory := func(system, bucket string) (claimcheck.S3Reader, error) {
-		gotSystem, gotBucket = system, bucket
-		return claimcheck.NewFakeS3Client(), nil
+			var gotSystem, gotBucket string
+			factory := func(system, bucket string) (claimcheck.S3Reader, error) {
+				gotSystem, gotBucket = system, bucket
+				return claimcheck.NewFakeS3Client(), nil
+			}
+
+			err := claimcheck.ResolveForTest(
+				factory,
+				&fakeEnvelopeDeserializer{envelope: envelope},
+				tc.topic,
+				[]byte("wire"),
+			)
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.system, gotSystem, "reader must assume the system stamped on the envelope")
+			assert.Equal(t, claimcheck.DefaultBucketResolver(tc.topic), gotBucket)
+		})
 	}
-
-	// Consumer's own system is "analytics" — must be ignored in favor of the issuer.
-	err := claimcheck.ResolveForTest(
-		factory,
-		"analytics",
-		&fakeEnvelopeDeserializer{envelope: envelope},
-		topic,
-		[]byte("wire"),
-	)
-	require.NoError(t, err)
-
-	assert.Equal(t, "billing", gotSystem, "reader must assume the producer's role, not the consumer's")
-	assert.Equal(t, claimcheck.DefaultBucketResolver(topic), gotBucket)
 }
 
-// TestResolver_FallsBackToDefaultSystem verifies that legacy envelopes without a
-// system field fall back to the consumer's own system name.
-func TestResolver_FallsBackToDefaultSystem(t *testing.T) {
-	const topic = "billing.test.invoices"
-	envelope := envelopeForTopic(topic, "") // legacy envelope, no system
+// TestResolver_EmptySystemErrors verifies that an envelope without a system
+// (malformed or pre-system-field) is rejected rather than resolved via any
+// fallback. This holds regardless of whether the topic follows the convention.
+func TestResolver_EmptySystemErrors(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		topic string
+	}{
+		{"conventional shared topic", "test.water--obs.measurements--v1"},
+		{"conventional internal topic", "test.sys--billing.invoices--v1"},
+		{"non-conventional topic", "billing.test.invoices"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			envelope := envelopeForTopic(tc.topic, "") // no system
 
-	var gotSystem string
-	factory := func(system, _ string) (claimcheck.S3Reader, error) {
-		gotSystem = system
-		return claimcheck.NewFakeS3Client(), nil
+			factory := func(string, string) (claimcheck.S3Reader, error) {
+				t.Fatal("factory must not be called for an envelope with no system")
+				return nil, nil
+			}
+
+			err := claimcheck.ResolveForTest(
+				factory,
+				&fakeEnvelopeDeserializer{envelope: envelope},
+				tc.topic,
+				[]byte("wire"),
+			)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "has no system")
+		})
 	}
-
-	err := claimcheck.ResolveForTest(
-		factory,
-		"analytics",
-		&fakeEnvelopeDeserializer{envelope: envelope},
-		topic,
-		[]byte("wire"),
-	)
-	require.NoError(t, err)
-
-	assert.Equal(t, "analytics", gotSystem, "missing system must fall back to the consumer's own system")
-}
-
-// TestResolver_LegacyEnvelopeDerivesSharedSystemFromTopic verifies that a legacy
-// envelope (System == "") on a shared-product topic resolves to data-definitions
-// via topic-derivation, NOT to the consumer's own system.
-func TestResolver_LegacyEnvelopeDerivesSharedSystemFromTopic(t *testing.T) {
-	const topic = "test.water--obs.measurements--v1" // shared product
-	envelope := envelopeForTopic(topic, "")          // legacy: no system
-
-	var gotSystem string
-	factory := func(system, _ string) (claimcheck.S3Reader, error) {
-		gotSystem = system
-		return claimcheck.NewFakeS3Client(), nil
-	}
-
-	err := claimcheck.ResolveForTest(
-		factory,
-		"analytics",
-		&fakeEnvelopeDeserializer{envelope: envelope},
-		topic,
-		[]byte("wire"),
-	)
-	require.NoError(t, err)
-
-	assert.Equal(t, "data-definitions", gotSystem,
-		"legacy envelope on a shared topic must derive data-definitions, not the consumer's system")
-}
-
-// TestResolver_LegacyEnvelopeNonConventionalTopicFallsBack verifies that a legacy
-// envelope on a non-conventional topic (resolver returns "") still falls back to
-// the consumer's own system.
-func TestResolver_LegacyEnvelopeNonConventionalTopicFallsBack(t *testing.T) {
-	const topic = "billing.test.invoices" // no "--" in domain segment -> resolver ""
-	envelope := envelopeForTopic(topic, "")
-
-	var gotSystem string
-	factory := func(system, _ string) (claimcheck.S3Reader, error) {
-		gotSystem = system
-		return claimcheck.NewFakeS3Client(), nil
-	}
-
-	err := claimcheck.ResolveForTest(
-		factory,
-		"analytics",
-		&fakeEnvelopeDeserializer{envelope: envelope},
-		topic,
-		[]byte("wire"),
-	)
-	require.NoError(t, err)
-
-	assert.Equal(t, "analytics", gotSystem)
 }

--- a/kafkarator/claimcheck/s3_client.go
+++ b/kafkarator/claimcheck/s3_client.go
@@ -242,27 +242,30 @@ func (p *s3Client) DeleteObject(ctx context.Context, bucket, key string) error {
 }
 
 // defaultS3WriterFactory returns a caching factory that creates a production
-// S3Writer for each unique bucket on first use. Called when no WithWriterS3Client
-// option is provided to NewWriter.
+// S3Writer for each unique (system, bucket) pair on first use. Called when no
+// WithWriterS3Client option is provided to NewWriter.
 //
-// The provided exchanger is shared across all bucket clients to avoid
-// concurrent token exchanges racing on the same awsTokenFile.
-func defaultS3WriterFactory(exchanger *tokenExchanger, system, env string) func(bucket string) (S3Writer, error) {
+// The system is the owner of the bucket (resolved from the topic): for a shared
+// data-product the producer must assume the data-definitions role, not its own.
+// The provided exchanger is shared across all clients to avoid concurrent token
+// exchanges racing on the same awsTokenFile.
+func defaultS3WriterFactory(exchanger *tokenExchanger, env string) func(system, bucket string) (S3Writer, error) {
 	var (
 		mu    sync.Mutex
 		cache = map[string]S3Writer{}
 	)
-	return func(bucket string) (S3Writer, error) {
+	return func(system, bucket string) (S3Writer, error) {
 		mu.Lock()
 		defer mu.Unlock()
-		if c, ok := cache[bucket]; ok {
+		key := system + "\x00" + bucket
+		if c, ok := cache[key]; ok {
 			return c, nil
 		}
 		c, err := newS3Client(bucket, "rw", system, env, exchanger)
 		if err != nil {
 			return nil, err
 		}
-		cache[bucket] = c
+		cache[key] = c
 		return c, nil
 	}
 }

--- a/kafkarator/claimcheck/s3_client.go
+++ b/kafkarator/claimcheck/s3_client.go
@@ -267,10 +267,33 @@ func defaultS3WriterFactory(exchanger *tokenExchanger, system, env string) func(
 	}
 }
 
-// defaultS3ReaderFor creates a production S3Reader for the given bucket.
-// Called when no WithProcessorS3Client option is provided to NewProcessor.
-func defaultS3ReaderFor(bucket, system, env string) (S3Reader, error) {
-	return newS3Client(bucket, "r", system, env, nil)
+// defaultS3ReaderFactory returns a caching factory that creates a production
+// S3Reader for each unique (system, bucket) pair on first use. Called when no
+// WithProcessorS3Client option is provided to NewProcessor.
+//
+// The system is the producer named in the claim-check envelope: the bucket is
+// owned by that system, so the assumed IAM role must be scoped to it. The
+// provided exchanger is shared across all clients to avoid concurrent token
+// exchanges racing on the same awsTokenFile.
+func defaultS3ReaderFactory(exchanger *tokenExchanger, env string) s3ReaderFactory {
+	var (
+		mu    sync.Mutex
+		cache = map[string]S3Reader{}
+	)
+	return func(system, bucket string) (S3Reader, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		key := system + "\x00" + bucket
+		if c, ok := cache[key]; ok {
+			return c, nil
+		}
+		c, err := newS3Client(bucket, "r", system, env, exchanger)
+		if err != nil {
+			return nil, err
+		}
+		cache[key] = c
+		return c, nil
+	}
 }
 
 // isError is a helper to check for AWS SDK typed errors.

--- a/kafkarator/claimcheck/stager.go
+++ b/kafkarator/claimcheck/stager.go
@@ -46,9 +46,6 @@ type stager struct {
 	s3Factory      func(system, bucket string) (S3Writer, error)
 	schemaFetcher  SchemaFetcher
 	ser            serializer
-	defaultSystem  string
-	systemResolver SystemResolver
-	systemOverride string
 	bucketResolver BucketResolver
 	rowGroupSize   int
 	partSize       int
@@ -60,28 +57,6 @@ type stagerOption func(*stager)
 
 func withBucketResolver(fn BucketResolver) stagerOption {
 	return func(s *stager) { s.bucketResolver = fn }
-}
-
-// withSystem sets the fallback system used when the resolver cannot derive one
-// from the topic (the producer's own system). The resolved/overridden system is
-// both stamped onto the envelope and used to build the write client's role.
-func withSystem(system string) stagerOption {
-	return func(s *stager) { s.defaultSystem = system }
-}
-
-// withSystemResolver overrides the default topic→system derivation.
-func withSystemResolver(fn SystemResolver) stagerOption {
-	return func(s *stager) {
-		if fn != nil {
-			s.systemResolver = fn
-		}
-	}
-}
-
-// withSystemOverride forces the owning system, bypassing the resolver entirely.
-// It sets both the write role and the stamped envelope system.
-func withSystemOverride(system string) stagerOption {
-	return func(s *stager) { s.systemOverride = system }
 }
 
 func withRowGroupSize(n int) stagerOption {
@@ -129,7 +104,6 @@ func newStagerWithFactory(
 		schemaFetcher:  fetcher,
 		ser:            ser,
 		bucketResolver: DefaultBucketResolver,
-		systemResolver: DefaultSystemResolver,
 		rowGroupSize:   defaultRowGroupSize,
 		partSize:       minPartSize,
 		tracer:         nooptrace.NewTracerProvider().Tracer(""),
@@ -164,7 +138,13 @@ func (s *stager) stage(ctx context.Context, topic string) (*Batch, error) {
 		return nil, fmt.Errorf("claimcheck: bucket resolver returned empty string for topic %q", topic)
 	}
 
-	system := s.resolveSystem(topic)
+	system := deriveSystemFromTopic(topic)
+	if system == "" {
+		return nil, fmt.Errorf(
+			"claimcheck: cannot derive owning system from topic %q; topic must follow the <env>.sys--<system>.<...> or <env>.<domain>--<sub>.<...> convention",
+			topic,
+		)
+	}
 
 	s3Client, err := s.s3Factory(system, bucket)
 	if err != nil {
@@ -210,20 +190,6 @@ func (s *stager) stage(ctx context.Context, topic string) (*Batch, error) {
 		pw:       parquet.NewGenericWriter[any](pipe, writerOpts...),
 		rowGroup: s.rowGroupSize,
 	}, nil
-}
-
-// resolveSystem determines the system that owns topic's bucket. An explicit
-// override wins; otherwise the resolver decides; otherwise the producer's own
-// system (defaultSystem) is the fallback for non-conventional topics. The result
-// is used for both the write role and the stamped envelope system.
-func (s *stager) resolveSystem(topic string) string {
-	if s.systemOverride != "" {
-		return s.systemOverride
-	}
-	if sys := s.systemResolver(topic); sys != "" {
-		return sys
-	}
-	return s.defaultSystem
 }
 
 // Batch is an open write session returned by [Writer.NewBatch]. Write records

--- a/kafkarator/claimcheck/stager.go
+++ b/kafkarator/claimcheck/stager.go
@@ -278,7 +278,7 @@ func (b *Batch) finalizeUpload(ctx context.Context) ([]byte, error) {
 		return nil, fmt.Errorf("claimcheck: close parquet writer: %w", err)
 	}
 	byteSize := b.pipe.Size()
-	env := &Envelope{
+	envelope := &Envelope{
 		BatchID:     b.batchID,
 		StorageURI:  "s3://" + b.pipe.bucket + "/" + b.pipe.key,
 		Topic:       b.topic,
@@ -287,7 +287,7 @@ func (b *Batch) finalizeUpload(ctx context.Context) ([]byte, error) {
 		ByteSize:    byteSize,
 		CreatedAt:   time.Now().UTC().UnixMilli(),
 	}
-	value, err := b.ser.Serialize(ctx, b.topic, env)
+	value, err := b.ser.Serialize(ctx, b.topic, envelope)
 	if err != nil {
 		b.pipe.Abort()
 		b.span.RecordError(err)

--- a/kafkarator/claimcheck/stager.go
+++ b/kafkarator/claimcheck/stager.go
@@ -43,10 +43,12 @@ type SchemaFetcher interface {
 // stager fetches the payload Avro schema from Schema Registry, converts it to
 // a Parquet schema, and opens write sessions to S3.
 type stager struct {
-	s3Factory      func(bucket string) (S3Writer, error)
+	s3Factory      func(system, bucket string) (S3Writer, error)
 	schemaFetcher  SchemaFetcher
 	ser            serializer
-	system         string
+	defaultSystem  string
+	systemResolver SystemResolver
+	systemOverride string
 	bucketResolver BucketResolver
 	rowGroupSize   int
 	partSize       int
@@ -60,10 +62,26 @@ func withBucketResolver(fn BucketResolver) stagerOption {
 	return func(s *stager) { s.bucketResolver = fn }
 }
 
-// withSystem sets the producing system name stamped onto each envelope so that
-// readers can assume the producer's Ceph IAM role.
+// withSystem sets the fallback system used when the resolver cannot derive one
+// from the topic (the producer's own system). The resolved/overridden system is
+// both stamped onto the envelope and used to build the write client's role.
 func withSystem(system string) stagerOption {
-	return func(s *stager) { s.system = system }
+	return func(s *stager) { s.defaultSystem = system }
+}
+
+// withSystemResolver overrides the default topic→system derivation.
+func withSystemResolver(fn SystemResolver) stagerOption {
+	return func(s *stager) {
+		if fn != nil {
+			s.systemResolver = fn
+		}
+	}
+}
+
+// withSystemOverride forces the owning system, bypassing the resolver entirely.
+// It sets both the write role and the stamped envelope system.
+func withSystemOverride(system string) stagerOption {
+	return func(s *stager) { s.systemOverride = system }
 }
 
 func withRowGroupSize(n int) stagerOption {
@@ -98,10 +116,10 @@ func withLogger(l *slog.Logger) stagerOption {
 	}
 }
 
-// newStagerWithFactory creates a stager that calls factory(bucket) to obtain
-// the S3Writer for each unique bucket.
+// newStagerWithFactory creates a stager that calls factory(system, bucket) to obtain
+// the S3Writer for each unique (system, bucket) pair.
 func newStagerWithFactory(
-	factory func(bucket string) (S3Writer, error),
+	factory func(system, bucket string) (S3Writer, error),
 	fetcher SchemaFetcher,
 	ser serializer,
 	opts ...stagerOption,
@@ -111,6 +129,7 @@ func newStagerWithFactory(
 		schemaFetcher:  fetcher,
 		ser:            ser,
 		bucketResolver: DefaultBucketResolver,
+		systemResolver: DefaultSystemResolver,
 		rowGroupSize:   defaultRowGroupSize,
 		partSize:       minPartSize,
 		tracer:         nooptrace.NewTracerProvider().Tracer(""),
@@ -145,9 +164,11 @@ func (s *stager) stage(ctx context.Context, topic string) (*Batch, error) {
 		return nil, fmt.Errorf("claimcheck: bucket resolver returned empty string for topic %q", topic)
 	}
 
-	s3Client, err := s.s3Factory(bucket)
+	system := s.resolveSystem(topic)
+
+	s3Client, err := s.s3Factory(system, bucket)
 	if err != nil {
-		return nil, fmt.Errorf("claimcheck: create S3 writer for bucket %q: %w", bucket, err)
+		return nil, fmt.Errorf("claimcheck: create S3 writer for system %q bucket %q: %w", system, bucket, err)
 	}
 
 	batchID := uuid.New().String()
@@ -181,7 +202,7 @@ func (s *stager) stage(ctx context.Context, topic string) (*Batch, error) {
 	return &Batch{
 		topic:    topic,
 		batchID:  batchID,
-		system:   s.system,
+		system:   system,
 		pipe:     pipe,
 		span:     span,
 		logger:   s.logger,
@@ -189,6 +210,20 @@ func (s *stager) stage(ctx context.Context, topic string) (*Batch, error) {
 		pw:       parquet.NewGenericWriter[any](pipe, writerOpts...),
 		rowGroup: s.rowGroupSize,
 	}, nil
+}
+
+// resolveSystem determines the system that owns topic's bucket. An explicit
+// override wins; otherwise the resolver decides; otherwise the producer's own
+// system (defaultSystem) is the fallback for non-conventional topics. The result
+// is used for both the write role and the stamped envelope system.
+func (s *stager) resolveSystem(topic string) string {
+	if s.systemOverride != "" {
+		return s.systemOverride
+	}
+	if sys := s.systemResolver(topic); sys != "" {
+		return sys
+	}
+	return s.defaultSystem
 }
 
 // Batch is an open write session returned by [Writer.NewBatch]. Write records

--- a/kafkarator/claimcheck/stager.go
+++ b/kafkarator/claimcheck/stager.go
@@ -138,7 +138,7 @@ func (s *stager) stage(ctx context.Context, topic string) (*Batch, error) {
 		return nil, fmt.Errorf("claimcheck: bucket resolver returned empty string for topic %q", topic)
 	}
 
-	system := deriveSystemFromTopic(topic)
+	system := owningSystem(topic)
 	if system == "" {
 		return nil, fmt.Errorf(
 			"claimcheck: cannot derive owning system from topic %q; topic must follow the <env>.sys--<system>.<...> or <env>.<domain>--<sub>.<...> convention",

--- a/kafkarator/claimcheck/stager.go
+++ b/kafkarator/claimcheck/stager.go
@@ -46,6 +46,7 @@ type stager struct {
 	s3Factory      func(bucket string) (S3Writer, error)
 	schemaFetcher  SchemaFetcher
 	ser            serializer
+	system         string
 	bucketResolver BucketResolver
 	rowGroupSize   int
 	partSize       int
@@ -57,6 +58,12 @@ type stagerOption func(*stager)
 
 func withBucketResolver(fn BucketResolver) stagerOption {
 	return func(s *stager) { s.bucketResolver = fn }
+}
+
+// withSystem sets the producing system name stamped onto each envelope so that
+// readers can assume the producer's Ceph IAM role.
+func withSystem(system string) stagerOption {
+	return func(s *stager) { s.system = system }
 }
 
 func withRowGroupSize(n int) stagerOption {
@@ -174,6 +181,7 @@ func (s *stager) stage(ctx context.Context, topic string) (*Batch, error) {
 	return &Batch{
 		topic:    topic,
 		batchID:  batchID,
+		system:   s.system,
 		pipe:     pipe,
 		span:     span,
 		logger:   s.logger,
@@ -200,6 +208,7 @@ type Batch struct {
 	produce func(ctx context.Context, value []byte) error
 	topic   string
 	batchID string
+	system  string
 	pipe    *multipartWriter
 	span    trace.Span
 	logger  *slog.Logger
@@ -238,6 +247,7 @@ func (b *Batch) finalizeUpload(ctx context.Context) ([]byte, error) {
 		BatchID:     b.batchID,
 		StorageURI:  "s3://" + b.pipe.bucket + "/" + b.pipe.key,
 		Topic:       b.topic,
+		System:      b.system,
 		RecordCount: b.recordCount,
 		ByteSize:    byteSize,
 		CreatedAt:   time.Now().UTC().UnixMilli(),

--- a/kafkarator/claimcheck/system_resolver.go
+++ b/kafkarator/claimcheck/system_resolver.go
@@ -8,7 +8,7 @@ import "strings"
 // it here and nowhere else.
 const dataDefinitionsSystem = "data-definitions"
 
-// deriveSystemFromTopic parses snappirator's topic convention
+// owningSystem parses snappirator's topic convention
 //
 //	<env>.<domain-segment>.<unqualified...>
 //
@@ -21,7 +21,7 @@ const dataDefinitionsSystem = "data-definitions"
 // The system is derived solely from the topic and is never overridable. env is
 // intentionally ignored: the shared system is the bare constant, and the ARN env
 // comes from the connection config.
-func deriveSystemFromTopic(topic string) string {
+func owningSystem(topic string) string {
 	parts := strings.SplitN(topic, ".", 3)
 	if len(parts) < 3 {
 		return ""
@@ -30,8 +30,5 @@ func deriveSystemFromTopic(topic string) string {
 	if system, ok := strings.CutPrefix(domain, "sys--"); ok {
 		return system // "" when domain is exactly "sys--" (malformed) -> caller errors
 	}
-	if strings.Contains(domain, "--") {
-		return dataDefinitionsSystem
-	}
-	return ""
+	return dataDefinitionsSystem // shared product (domain--sub) -> data-definitions
 }

--- a/kafkarator/claimcheck/system_resolver.go
+++ b/kafkarator/claimcheck/system_resolver.go
@@ -1,0 +1,39 @@
+package claimcheck
+
+import "strings"
+
+// dataDefinitionsSystem is the Happi system that owns the claim-check buckets
+// for shared data-products. It is the single source of truth: if the
+// provisioned Ceph role path ever changes (e.g. becomes env-suffixed), change
+// it here and nowhere else.
+const dataDefinitionsSystem = "data-definitions"
+
+// SystemResolver maps a topic name to the Happi system that owns its
+// claim-check bucket (the system whose Ceph IAM role must be assumed).
+type SystemResolver func(topic string) string
+
+// DefaultSystemResolver parses snappirator's topic convention
+//
+//	<env>.<domain-segment>.<unqualified...>
+//
+// and returns the owning system:
+//   - domain segment "sys--<system>"   -> "<system>"         (internal product)
+//   - domain segment "<domain>--<sub>" -> "data-definitions" (shared product)
+//   - otherwise                        -> ""  (caller falls back to its own system)
+//
+// env is intentionally ignored: the shared system is the bare constant, and the
+// ARN env comes from the connection config.
+func DefaultSystemResolver(topic string) string {
+	parts := strings.SplitN(topic, ".", 3)
+	if len(parts) < 3 {
+		return ""
+	}
+	domain := parts[1]
+	if system, ok := strings.CutPrefix(domain, "sys--"); ok {
+		return system // "" when domain is exactly "sys--" (malformed) -> caller falls back
+	}
+	if strings.Contains(domain, "--") {
+		return dataDefinitionsSystem
+	}
+	return ""
+}

--- a/kafkarator/claimcheck/system_resolver.go
+++ b/kafkarator/claimcheck/system_resolver.go
@@ -8,29 +8,27 @@ import "strings"
 // it here and nowhere else.
 const dataDefinitionsSystem = "data-definitions"
 
-// SystemResolver maps a topic name to the Happi system that owns its
-// claim-check bucket (the system whose Ceph IAM role must be assumed).
-type SystemResolver func(topic string) string
-
-// DefaultSystemResolver parses snappirator's topic convention
+// deriveSystemFromTopic parses snappirator's topic convention
 //
 //	<env>.<domain-segment>.<unqualified...>
 //
-// and returns the owning system:
+// and returns the Happi system that owns the topic's claim-check bucket (the
+// system whose Ceph IAM role must be assumed):
 //   - domain segment "sys--<system>"   -> "<system>"         (internal product)
 //   - domain segment "<domain>--<sub>" -> "data-definitions" (shared product)
-//   - otherwise                        -> ""  (caller falls back to its own system)
+//   - otherwise                        -> ""  (non-conventional topic; the caller errors)
 //
-// env is intentionally ignored: the shared system is the bare constant, and the
-// ARN env comes from the connection config.
-func DefaultSystemResolver(topic string) string {
+// The system is derived solely from the topic and is never overridable. env is
+// intentionally ignored: the shared system is the bare constant, and the ARN env
+// comes from the connection config.
+func deriveSystemFromTopic(topic string) string {
 	parts := strings.SplitN(topic, ".", 3)
 	if len(parts) < 3 {
 		return ""
 	}
 	domain := parts[1]
 	if system, ok := strings.CutPrefix(domain, "sys--"); ok {
-		return system // "" when domain is exactly "sys--" (malformed) -> caller falls back
+		return system // "" when domain is exactly "sys--" (malformed) -> caller errors
 	}
 	if strings.Contains(domain, "--") {
 		return dataDefinitionsSystem

--- a/kafkarator/claimcheck/system_resolver_test.go
+++ b/kafkarator/claimcheck/system_resolver_test.go
@@ -1,14 +1,12 @@
-package claimcheck_test
+package claimcheck
 
 import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
-	"github.com/hafslundkraft/golib/kafkarator/claimcheck"
 )
 
-func TestDefaultSystemResolver(t *testing.T) {
+func TestDeriveSystemFromTopic(t *testing.T) {
 	for _, tc := range []struct {
 		name  string
 		topic string
@@ -25,7 +23,7 @@ func TestDefaultSystemResolver(t *testing.T) {
 		{"empty topic", "", ""},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.want, claimcheck.DefaultSystemResolver(tc.topic))
+			assert.Equal(t, tc.want, deriveSystemFromTopic(tc.topic))
 		})
 	}
 }

--- a/kafkarator/claimcheck/system_resolver_test.go
+++ b/kafkarator/claimcheck/system_resolver_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestDeriveSystemFromTopic(t *testing.T) {
+func TestOwningSystem(t *testing.T) {
 	for _, tc := range []struct {
 		name  string
 		topic string
@@ -18,12 +18,12 @@ func TestDeriveSystemFromTopic(t *testing.T) {
 		{"unqualified name with dots", "test.sys--billing.invoices.extra", "billing"},
 		{"two segments only", "test.invoices", ""},
 		{"single segment", "invoices", ""},
-		{"no double-dash in domain", "test.billing.invoices", ""},
+		{"no double-dash in domain", "test.billing.invoices", "data-definitions"},
 		{"empty system after sys--", "test.sys--.invoices", ""},
 		{"empty topic", "", ""},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.want, deriveSystemFromTopic(tc.topic))
+			assert.Equal(t, tc.want, owningSystem(tc.topic))
 		})
 	}
 }

--- a/kafkarator/claimcheck/system_resolver_test.go
+++ b/kafkarator/claimcheck/system_resolver_test.go
@@ -1,0 +1,31 @@
+package claimcheck_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/hafslundkraft/golib/kafkarator/claimcheck"
+)
+
+func TestDefaultSystemResolver(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		topic string
+		want  string
+	}{
+		{"internal product", "test.sys--billing.invoices--v1", "billing"},
+		{"shared product", "test.water--obs.measurements--v1", "data-definitions"},
+		{"internal in prod env", "prod.sys--metering.readings--v2", "metering"},
+		{"unqualified name with dots", "test.sys--billing.invoices.extra", "billing"},
+		{"two segments only", "test.invoices", ""},
+		{"single segment", "invoices", ""},
+		{"no double-dash in domain", "test.billing.invoices", ""},
+		{"empty system after sys--", "test.sys--.invoices", ""},
+		{"empty topic", "", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, claimcheck.DefaultSystemResolver(tc.topic))
+		})
+	}
+}

--- a/kafkarator/claimcheck/writer.go
+++ b/kafkarator/claimcheck/writer.go
@@ -50,19 +50,6 @@ func WithWriterBucketResolver(fn BucketResolver) WriterOption {
 	return func(c *writerConfig) { c.stagerOpts = append(c.stagerOpts, withBucketResolver(fn)) }
 }
 
-// WithWriterSystem forces the owning system for every batch, bypassing topic
-// derivation. It sets both the assumed Ceph write role and the system stamped
-// onto each envelope — the two always agree.
-func WithWriterSystem(system string) WriterOption {
-	return func(c *writerConfig) { c.stagerOpts = append(c.stagerOpts, withSystemOverride(system)) }
-}
-
-// WithWriterSystemResolver overrides the default topic→system derivation used by
-// the writer to choose the bucket owner.
-func WithWriterSystemResolver(fn SystemResolver) WriterOption {
-	return func(c *writerConfig) { c.stagerOpts = append(c.stagerOpts, withSystemResolver(fn)) }
-}
-
 // WithWriterRowGroupSize sets the number of records per Parquet row group. Default is 100 000.
 func WithWriterRowGroupSize(n int) WriterOption {
 	return func(c *writerConfig) { c.stagerOpts = append(c.stagerOpts, withRowGroupSize(n)) }
@@ -126,7 +113,7 @@ func NewWriter(conn *kafkarator.Connection, opts ...WriterOption) (*Writer, erro
 	}
 
 	cfg.stagerOpts = append(
-		[]stagerOption{withTracer(conn.Tracer()), withLogger(conn.Logger()), withSystem(connCfg.SystemName)},
+		[]stagerOption{withTracer(conn.Tracer()), withLogger(conn.Logger())},
 		cfg.stagerOpts...,
 	)
 	stager := newStagerWithFactory(cfg.s3Factory, cfg.fetcher, conn.Serializer(), cfg.stagerOpts...)

--- a/kafkarator/claimcheck/writer.go
+++ b/kafkarator/claimcheck/writer.go
@@ -25,7 +25,7 @@ type Writer struct {
 type WriterOption func(*writerConfig)
 
 type writerConfig struct {
-	s3Factory  func(bucket string) (S3Writer, error)
+	s3Factory  func(system, bucket string) (S3Writer, error)
 	fetcher    SchemaFetcher
 	stagerOpts []stagerOption
 }
@@ -36,7 +36,7 @@ type writerConfig struct {
 // HAPPI_SYSTEM_NAME, HAPPI_ENV, and HAPPI_IDP_ISSUER_URL.
 func WithWriterS3Client(s3 S3Writer) WriterOption {
 	return func(c *writerConfig) {
-		c.s3Factory = func(_ string) (S3Writer, error) { return s3, nil }
+		c.s3Factory = func(_, _ string) (S3Writer, error) { return s3, nil }
 	}
 }
 
@@ -48,6 +48,19 @@ func WithWriterSchemaFetcher(f SchemaFetcher) WriterOption {
 // WithWriterBucketResolver overrides the default topic→bucket naming convention used by the writer.
 func WithWriterBucketResolver(fn BucketResolver) WriterOption {
 	return func(c *writerConfig) { c.stagerOpts = append(c.stagerOpts, withBucketResolver(fn)) }
+}
+
+// WithWriterSystem forces the owning system for every batch, bypassing topic
+// derivation. It sets both the assumed Ceph write role and the system stamped
+// onto each envelope — the two always agree.
+func WithWriterSystem(system string) WriterOption {
+	return func(c *writerConfig) { c.stagerOpts = append(c.stagerOpts, withSystemOverride(system)) }
+}
+
+// WithWriterSystemResolver overrides the default topic→system derivation used by
+// the writer to choose the bucket owner.
+func WithWriterSystemResolver(fn SystemResolver) WriterOption {
+	return func(c *writerConfig) { c.stagerOpts = append(c.stagerOpts, withSystemResolver(fn)) }
 }
 
 // WithWriterRowGroupSize sets the number of records per Parquet row group. Default is 100 000.
@@ -102,7 +115,7 @@ func NewWriter(conn *kafkarator.Connection, opts ...WriterOption) (*Writer, erro
 		if err != nil {
 			return nil, fmt.Errorf("claimcheck: init token exchanger: %w", err)
 		}
-		cfg.s3Factory = defaultS3WriterFactory(exchanger, connCfg.SystemName, connCfg.Env)
+		cfg.s3Factory = defaultS3WriterFactory(exchanger, connCfg.Env)
 	}
 	if cfg.fetcher == nil {
 		cfg.fetcher = newSRSchemaFetcher(conn.SchemaRegistryClient())

--- a/kafkarator/claimcheck/writer.go
+++ b/kafkarator/claimcheck/writer.go
@@ -96,8 +96,8 @@ func NewWriter(conn *kafkarator.Connection, opts ...WriterOption) (*Writer, erro
 	for _, o := range opts {
 		o(cfg)
 	}
+	connCfg := conn.Config()
 	if cfg.s3Factory == nil {
-		connCfg := conn.Config()
 		exchanger, err := newTokenExchanger()
 		if err != nil {
 			return nil, fmt.Errorf("claimcheck: init token exchanger: %w", err)
@@ -112,7 +112,10 @@ func NewWriter(conn *kafkarator.Connection, opts ...WriterOption) (*Writer, erro
 		return nil, fmt.Errorf("claimcheck: create kafka writer: %w", err)
 	}
 
-	cfg.stagerOpts = append([]stagerOption{withTracer(conn.Tracer()), withLogger(conn.Logger())}, cfg.stagerOpts...)
+	cfg.stagerOpts = append(
+		[]stagerOption{withTracer(conn.Tracer()), withLogger(conn.Logger()), withSystem(connCfg.SystemName)},
+		cfg.stagerOpts...,
+	)
 	stager := newStagerWithFactory(cfg.s3Factory, cfg.fetcher, conn.Serializer(), cfg.stagerOpts...)
 	return &Writer{kw: kw, stager: stager}, nil
 }

--- a/kafkarator/claimcheck/writer_test.go
+++ b/kafkarator/claimcheck/writer_test.go
@@ -394,7 +394,7 @@ func TestWriter_InternalTopicStampsOwnSystem(t *testing.T) {
 }
 
 func TestWriter_NonConventionalTopicErrors(t *testing.T) {
-	const topic = "billing.test" // no "--" in domain segment -> no derivable system
+	const topic = "billing.test" // no name segment -> no derivable system
 
 	kw := &captureKW{}
 	w := claimcheck.NewTestWriter(kw, &jsonSerializer{},

--- a/kafkarator/claimcheck/writer_test.go
+++ b/kafkarator/claimcheck/writer_test.go
@@ -339,6 +339,82 @@ func TestPayloadReader_ReadAtDoesNotMoveSequentialPosition(t *testing.T) {
 	_ = f
 }
 
+func TestWriter_SharedTopicStampsAndBuildsForDataDefinitions(t *testing.T) {
+	const topic = "test.water--obs.measurements--v1" // shared product
+
+	var gotSystem, gotBucket string
+	kw := &captureKW{}
+	w := claimcheck.NewTestWriter(kw, &jsonSerializer{},
+		claimcheck.WithWriterS3FactoryForTest(func(system, bucket string) (claimcheck.S3Writer, error) {
+			gotSystem, gotBucket = system, bucket
+			return claimcheck.NewFakeS3Client(), nil
+		}),
+		// Producer's own system is "billing" — must be ignored for a shared topic.
+		claimcheck.WithWriterSystemForTest("billing"),
+		claimcheck.WithWriterSchemaFetcher(&fakeSchemaFetcher{schemaStr: simpleSchema("id"), version: 1, id: 1}),
+	)
+
+	batch, err := w.NewBatch(context.Background(), topic)
+	require.NoError(t, err)
+	defer batch.Cleanup()
+	require.NoError(t, batch.Write(map[string]any{"id": int32(1)}))
+	require.NoError(t, batch.Produce(context.Background()))
+
+	assert.Equal(t, "data-definitions", gotSystem, "write client must be built for the bucket owner, not the producer")
+	assert.Equal(t, claimcheck.DefaultBucketResolver(topic), gotBucket)
+	env := unmarshalEnvelope(t, kw.last.Value)
+	assert.Equal(t, "data-definitions", env.System, "stamp must match the write role")
+}
+
+func TestWriter_InternalTopicStampsOwnSystem(t *testing.T) {
+	const topic = "test.sys--billing.invoices--v1" // internal product
+
+	var gotSystem string
+	kw := &captureKW{}
+	w := claimcheck.NewTestWriter(kw, &jsonSerializer{},
+		claimcheck.WithWriterS3FactoryForTest(func(system, _ string) (claimcheck.S3Writer, error) {
+			gotSystem = system
+			return claimcheck.NewFakeS3Client(), nil
+		}),
+		claimcheck.WithWriterSchemaFetcher(&fakeSchemaFetcher{schemaStr: simpleSchema("id"), version: 1, id: 1}),
+	)
+
+	batch, err := w.NewBatch(context.Background(), topic)
+	require.NoError(t, err)
+	defer batch.Cleanup()
+	require.NoError(t, batch.Write(map[string]any{"id": int32(1)}))
+	require.NoError(t, batch.Produce(context.Background()))
+
+	assert.Equal(t, "billing", gotSystem)
+	env := unmarshalEnvelope(t, kw.last.Value)
+	assert.Equal(t, "billing", env.System)
+}
+
+func TestWriter_WithWriterSystemOverridesBoth(t *testing.T) {
+	const topic = "test.water--obs.measurements--v1" // resolver would say data-definitions
+
+	var gotSystem string
+	kw := &captureKW{}
+	w := claimcheck.NewTestWriter(kw, &jsonSerializer{},
+		claimcheck.WithWriterS3FactoryForTest(func(system, _ string) (claimcheck.S3Writer, error) {
+			gotSystem = system
+			return claimcheck.NewFakeS3Client(), nil
+		}),
+		claimcheck.WithWriterSystem("override-sys"),
+		claimcheck.WithWriterSchemaFetcher(&fakeSchemaFetcher{schemaStr: simpleSchema("id"), version: 1, id: 1}),
+	)
+
+	batch, err := w.NewBatch(context.Background(), topic)
+	require.NoError(t, err)
+	defer batch.Cleanup()
+	require.NoError(t, batch.Write(map[string]any{"id": int32(1)}))
+	require.NoError(t, batch.Produce(context.Background()))
+
+	assert.Equal(t, "override-sys", gotSystem, "override must win over the resolver for the write role")
+	env := unmarshalEnvelope(t, kw.last.Value)
+	assert.Equal(t, "override-sys", env.System, "override must win over the resolver for the stamp")
+}
+
 // parquetKV extracts the Parquet key-value metadata footer as a map.
 func parquetKV(f *parquet.File) map[string]string {
 	m := make(map[string]string, len(f.Metadata().KeyValueMetadata))

--- a/kafkarator/claimcheck/writer_test.go
+++ b/kafkarator/claimcheck/writer_test.go
@@ -394,7 +394,7 @@ func TestWriter_InternalTopicStampsOwnSystem(t *testing.T) {
 }
 
 func TestWriter_NonConventionalTopicErrors(t *testing.T) {
-	const topic = "billing.test.invoices" // no "--" in domain segment -> no derivable system
+	const topic = "billing.test" // no "--" in domain segment -> no derivable system
 
 	kw := &captureKW{}
 	w := claimcheck.NewTestWriter(kw, &jsonSerializer{},

--- a/kafkarator/claimcheck/writer_test.go
+++ b/kafkarator/claimcheck/writer_test.go
@@ -36,7 +36,12 @@ func TestWriter_StampsProducerSystemOnEnvelope(t *testing.T) {
 	require.NoError(t, batch.Produce(context.Background()))
 
 	envelope := unmarshalEnvelope(t, kw.last.Value)
-	assert.Equal(t, "billing", envelope.System, "envelope must record the producing system for readers' ARN construction")
+	assert.Equal(
+		t,
+		"billing",
+		envelope.System,
+		"envelope must record the producing system for readers' ARN construction",
+	)
 }
 
 func TestMultipartWriter_CompleteFlushesSmallPayload(t *testing.T) {

--- a/kafkarator/claimcheck/writer_test.go
+++ b/kafkarator/claimcheck/writer_test.go
@@ -20,7 +20,6 @@ func TestWriter_StampsProducerSystemOnEnvelope(t *testing.T) {
 	kw := &captureKW{}
 	w := claimcheck.NewTestWriter(kw, &jsonSerializer{},
 		claimcheck.WithWriterS3Client(s3),
-		claimcheck.WithWriterSystemForTest("billing"),
 		claimcheck.WithWriterSchemaFetcher(&fakeSchemaFetcher{
 			schemaStr: simpleSchema("id"),
 			version:   1,
@@ -28,7 +27,8 @@ func TestWriter_StampsProducerSystemOnEnvelope(t *testing.T) {
 		}),
 	)
 
-	batch, err := w.NewBatch(context.Background(), "billing.test.invoices")
+	// Topic derives the owning system "billing"; it is never set by the caller.
+	batch, err := w.NewBatch(context.Background(), "test.sys--billing.invoices--v1")
 	require.NoError(t, err)
 	defer batch.Cleanup()
 
@@ -40,7 +40,7 @@ func TestWriter_StampsProducerSystemOnEnvelope(t *testing.T) {
 		t,
 		"billing",
 		envelope.System,
-		"envelope must record the producing system for readers' ARN construction",
+		"envelope must record the topic-derived owning system for readers' ARN construction",
 	)
 }
 
@@ -57,7 +57,7 @@ func TestMultipartWriter_CompleteFlushesSmallPayload(t *testing.T) {
 		}),
 	)
 
-	batch, err := w.NewBatch(context.Background(), "test-topic")
+	batch, err := w.NewBatch(context.Background(), "test.sys--demo.events--v1")
 	require.NoError(t, err)
 	defer batch.Cleanup()
 
@@ -65,7 +65,7 @@ func TestMultipartWriter_CompleteFlushesSmallPayload(t *testing.T) {
 	require.NoError(t, batch.Produce(context.Background()))
 
 	envelope := unmarshalEnvelope(t, kw.last.Value)
-	assert.Equal(t, "test-topic", envelope.Topic)
+	assert.Equal(t, "test.sys--demo.events--v1", envelope.Topic)
 	assert.Equal(t, int64(1), envelope.RecordCount)
 	assert.Positive(t, envelope.ByteSize)
 
@@ -84,7 +84,7 @@ func TestMultipartWriter_AbortLeavesNoObject(t *testing.T) {
 		}),
 	)
 
-	batch, err := w.NewBatch(context.Background(), "abort-topic")
+	batch, err := w.NewBatch(context.Background(), "test.sys--demo.aborts--v1")
 	require.NoError(t, err)
 	require.NoError(t, batch.Write(map[string]any{"id": int32(99)}))
 	batch.Cleanup()
@@ -108,15 +108,15 @@ func TestStager_UsesPayloadSubject(t *testing.T) {
 		claimcheck.WithWriterSchemaFetcher(fetcher),
 	)
 
-	batch, err := w.NewBatch(context.Background(), "demo-topic")
+	batch, err := w.NewBatch(context.Background(), "test.sys--demo.subjects--v1")
 	require.NoError(t, err)
 	batch.Cleanup()
 
-	assert.Equal(t, "demo-topic-claim-check-payload", fetcher.subject)
+	assert.Equal(t, "test.sys--demo.subjects--v1-claim-check-payload", fetcher.subject)
 }
 
 func TestStager_BucketDerivedFromResolver(t *testing.T) {
-	topic := "hash-check-topic"
+	topic := "test.sys--demo.buckets--v1"
 	expected := claimcheck.DefaultBucketResolver(topic)
 
 	var capturedBucket string
@@ -143,7 +143,7 @@ func TestBatch_WriteProduceAndReadRecords(t *testing.T) {
 		Name string `parquet:"name"`
 	}
 
-	const topic = "event-topic"
+	const topic = "test.sys--demo.records--v1"
 	schemaStr := `{"type":"record","name":"Event","fields":[{"name":"id","type":"int"},{"name":"name","type":"string"}]}`
 	s3 := claimcheck.NewFakeS3Client()
 	kw := &captureKW{}
@@ -183,7 +183,7 @@ func TestBatch_KeyAndHeadersPropagated(t *testing.T) {
 		claimcheck.WithWriterSchemaFetcher(&fakeSchemaFetcher{schemaStr: simpleSchema("v"), version: 1, id: 1}),
 	)
 
-	batch, err := w.NewBatch(context.Background(), "keyed-topic",
+	batch, err := w.NewBatch(context.Background(), "test.sys--demo.keyed--v1",
 		claimcheck.WithBatchKey([]byte("my-key")),
 		claimcheck.WithBatchHeaders(map[string][]byte{"x-source": []byte("test")}),
 	)
@@ -198,7 +198,7 @@ func TestBatch_KeyAndHeadersPropagated(t *testing.T) {
 }
 
 func TestBatch_FlushesMultipleRowGroups(t *testing.T) {
-	const topic = "rowgroup-topic"
+	const topic = "test.sys--demo.rowgroups--v1"
 	schemaStr := `{"type":"record","name":"RG","fields":[{"name":"id","type":"int"}]}`
 	s3 := claimcheck.NewFakeS3Client()
 	kw := &captureKW{}
@@ -233,7 +233,7 @@ func TestBatch_FlushesMultipleRowGroups(t *testing.T) {
 }
 
 func TestBatch_ParquetFooterEmbeddsAvroMetadata(t *testing.T) {
-	const topic = "meta-topic"
+	const topic = "test.sys--demo.meta--v1"
 	schemaStr := `{"type":"record","name":"M","fields":[{"name":"v","type":"long"}]}`
 	s3 := claimcheck.NewFakeS3Client()
 	kw := &captureKW{}
@@ -269,7 +269,7 @@ func TestBatch_ProduceAfterCleanupReturnsError(t *testing.T) {
 		claimcheck.WithWriterSchemaFetcher(&fakeSchemaFetcher{schemaStr: simpleSchema("id"), version: 1, id: 1}),
 	)
 
-	batch, err := w.NewBatch(context.Background(), "double-close")
+	batch, err := w.NewBatch(context.Background(), "test.sys--demo.doubleclose--v1")
 	require.NoError(t, err)
 
 	batch.Cleanup()
@@ -284,7 +284,7 @@ func TestBatch_CleanupAfterProduceIsNoop(t *testing.T) {
 		claimcheck.WithWriterSchemaFetcher(&fakeSchemaFetcher{schemaStr: simpleSchema("v"), version: 1, id: 1}),
 	)
 
-	batch, err := w.NewBatch(context.Background(), "noop-abort")
+	batch, err := w.NewBatch(context.Background(), "test.sys--demo.noopabort--v1")
 	require.NoError(t, err)
 	defer batch.Cleanup()
 
@@ -299,7 +299,7 @@ func TestPayloadReader_ReadAtDoesNotMoveSequentialPosition(t *testing.T) {
 	type R struct {
 		ID int32 `parquet:"id"`
 	}
-	const topic = "readat-independence-topic"
+	const topic = "test.sys--demo.readat--v1"
 	schemaStr := `{"type":"record","name":"R","fields":[{"name":"id","type":"int"}]}`
 	s3 := claimcheck.NewFakeS3Client()
 	kw := &captureKW{}
@@ -354,8 +354,6 @@ func TestWriter_SharedTopicStampsAndBuildsForDataDefinitions(t *testing.T) {
 			gotSystem, gotBucket = system, bucket
 			return claimcheck.NewFakeS3Client(), nil
 		}),
-		// Producer's own system is "billing" — must be ignored for a shared topic.
-		claimcheck.WithWriterSystemForTest("billing"),
 		claimcheck.WithWriterSchemaFetcher(&fakeSchemaFetcher{schemaStr: simpleSchema("id"), version: 1, id: 1}),
 	)
 
@@ -395,29 +393,21 @@ func TestWriter_InternalTopicStampsOwnSystem(t *testing.T) {
 	assert.Equal(t, "billing", envelope.System)
 }
 
-func TestWriter_WithWriterSystemOverridesBoth(t *testing.T) {
-	const topic = "test.water--obs.measurements--v1" // resolver would say data-definitions
+func TestWriter_NonConventionalTopicErrors(t *testing.T) {
+	const topic = "billing.test.invoices" // no "--" in domain segment -> no derivable system
 
-	var gotSystem string
 	kw := &captureKW{}
 	w := claimcheck.NewTestWriter(kw, &jsonSerializer{},
-		claimcheck.WithWriterS3FactoryForTest(func(system, _ string) (claimcheck.S3Writer, error) {
-			gotSystem = system
-			return claimcheck.NewFakeS3Client(), nil
+		claimcheck.WithWriterS3FactoryForTest(func(string, string) (claimcheck.S3Writer, error) {
+			t.Fatal("S3 writer factory must not be called when the system cannot be derived")
+			return nil, nil
 		}),
-		claimcheck.WithWriterSystem("override-sys"),
 		claimcheck.WithWriterSchemaFetcher(&fakeSchemaFetcher{schemaStr: simpleSchema("id"), version: 1, id: 1}),
 	)
 
-	batch, err := w.NewBatch(context.Background(), topic)
-	require.NoError(t, err)
-	defer batch.Cleanup()
-	require.NoError(t, batch.Write(map[string]any{"id": int32(1)}))
-	require.NoError(t, batch.Produce(context.Background()))
-
-	assert.Equal(t, "override-sys", gotSystem, "override must win over the resolver for the write role")
-	envelope := unmarshalEnvelope(t, kw.last.Value)
-	assert.Equal(t, "override-sys", envelope.System, "override must win over the resolver for the stamp")
+	_, err := w.NewBatch(context.Background(), topic)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot derive owning system")
 }
 
 // parquetKV extracts the Parquet key-value metadata footer as a map.

--- a/kafkarator/claimcheck/writer_test.go
+++ b/kafkarator/claimcheck/writer_test.go
@@ -15,6 +15,30 @@ import (
 	"github.com/hafslundkraft/golib/kafkarator/claimcheck"
 )
 
+func TestWriter_StampsProducerSystemOnEnvelope(t *testing.T) {
+	s3 := claimcheck.NewFakeS3Client()
+	kw := &captureKW{}
+	w := claimcheck.NewTestWriter(kw, &jsonSerializer{},
+		claimcheck.WithWriterS3Client(s3),
+		claimcheck.WithWriterSystemForTest("billing"),
+		claimcheck.WithWriterSchemaFetcher(&fakeSchemaFetcher{
+			schemaStr: simpleSchema("id"),
+			version:   1,
+			id:        42,
+		}),
+	)
+
+	batch, err := w.NewBatch(context.Background(), "billing.test.invoices")
+	require.NoError(t, err)
+	defer batch.Cleanup()
+
+	require.NoError(t, batch.Write(map[string]any{"id": int32(1)}))
+	require.NoError(t, batch.Produce(context.Background()))
+
+	env := unmarshalEnvelope(t, kw.last.Value)
+	assert.Equal(t, "billing", env.System, "envelope must record the producing system for readers' ARN construction")
+}
+
 func TestMultipartWriter_CompleteFlushesSmallPayload(t *testing.T) {
 	// Write < minPartSize bytes; Complete must still upload them.
 	s3 := claimcheck.NewFakeS3Client()

--- a/kafkarator/claimcheck/writer_test.go
+++ b/kafkarator/claimcheck/writer_test.go
@@ -35,8 +35,8 @@ func TestWriter_StampsProducerSystemOnEnvelope(t *testing.T) {
 	require.NoError(t, batch.Write(map[string]any{"id": int32(1)}))
 	require.NoError(t, batch.Produce(context.Background()))
 
-	env := unmarshalEnvelope(t, kw.last.Value)
-	assert.Equal(t, "billing", env.System, "envelope must record the producing system for readers' ARN construction")
+	envelope := unmarshalEnvelope(t, kw.last.Value)
+	assert.Equal(t, "billing", envelope.System, "envelope must record the producing system for readers' ARN construction")
 }
 
 func TestMultipartWriter_CompleteFlushesSmallPayload(t *testing.T) {
@@ -59,12 +59,12 @@ func TestMultipartWriter_CompleteFlushesSmallPayload(t *testing.T) {
 	require.NoError(t, batch.Write(map[string]any{"id": int32(1)}))
 	require.NoError(t, batch.Produce(context.Background()))
 
-	env := unmarshalEnvelope(t, kw.last.Value)
-	assert.Equal(t, "test-topic", env.Topic)
-	assert.Equal(t, int64(1), env.RecordCount)
-	assert.Positive(t, env.ByteSize)
+	envelope := unmarshalEnvelope(t, kw.last.Value)
+	assert.Equal(t, "test-topic", envelope.Topic)
+	assert.Equal(t, int64(1), envelope.RecordCount)
+	assert.Positive(t, envelope.ByteSize)
 
-	bucket, key := bucketAndKey(t, env.StorageURI)
+	bucket, key := bucketAndKey(t, envelope.StorageURI)
 	assert.NotEmpty(t, s3.Store[bucket+"/"+key])
 }
 
@@ -157,8 +157,8 @@ func TestBatch_WriteProduceAndReadRecords(t *testing.T) {
 	}
 	require.NoError(t, batch.Produce(context.Background()))
 
-	env := unmarshalEnvelope(t, kw.last.Value)
-	msg := claimcheck.NewMessage(topic, nil, kw.last.Value, nil, s3, &fakeEnvelopeDeserializer{env: env})
+	envelope := unmarshalEnvelope(t, kw.last.Value)
+	msg := claimcheck.NewMessage(topic, nil, kw.last.Value, nil, s3, &fakeEnvelopeDeserializer{envelope: envelope})
 
 	var got []Event
 	for r, err := range claimcheck.Records[Event](context.Background(), msg) {
@@ -210,8 +210,8 @@ func TestBatch_FlushesMultipleRowGroups(t *testing.T) {
 	}
 	require.NoError(t, batch.Produce(context.Background()))
 
-	env := unmarshalEnvelope(t, kw.last.Value)
-	msg := claimcheck.NewMessage(topic, nil, kw.last.Value, nil, s3, &fakeEnvelopeDeserializer{env: env})
+	envelope := unmarshalEnvelope(t, kw.last.Value)
+	msg := claimcheck.NewMessage(topic, nil, kw.last.Value, nil, s3, &fakeEnvelopeDeserializer{envelope: envelope})
 	pr, err := msg.Payload(context.Background())
 	require.NoError(t, err)
 	defer pr.Close()
@@ -242,8 +242,8 @@ func TestBatch_ParquetFooterEmbeddsAvroMetadata(t *testing.T) {
 	require.NoError(t, batch.Write(map[string]any{"v": int64(42)}))
 	require.NoError(t, batch.Produce(context.Background()))
 
-	env := unmarshalEnvelope(t, kw.last.Value)
-	bucket, key := bucketAndKey(t, env.StorageURI)
+	envelope := unmarshalEnvelope(t, kw.last.Value)
+	bucket, key := bucketAndKey(t, envelope.StorageURI)
 	data := s3.Store[bucket+"/"+key]
 	require.NotEmpty(t, data)
 
@@ -310,8 +310,8 @@ func TestPayloadReader_ReadAtDoesNotMoveSequentialPosition(t *testing.T) {
 	}
 	require.NoError(t, batch.Produce(context.Background()))
 
-	env := unmarshalEnvelope(t, kw.last.Value)
-	msg := claimcheck.NewMessage(topic, nil, kw.last.Value, nil, s3, &fakeEnvelopeDeserializer{env: env})
+	envelope := unmarshalEnvelope(t, kw.last.Value)
+	msg := claimcheck.NewMessage(topic, nil, kw.last.Value, nil, s3, &fakeEnvelopeDeserializer{envelope: envelope})
 
 	// Open PayloadReader — parquet.OpenFile will issue ReadAt calls for the footer.
 	pr, err := msg.Payload(context.Background())
@@ -362,8 +362,8 @@ func TestWriter_SharedTopicStampsAndBuildsForDataDefinitions(t *testing.T) {
 
 	assert.Equal(t, "data-definitions", gotSystem, "write client must be built for the bucket owner, not the producer")
 	assert.Equal(t, claimcheck.DefaultBucketResolver(topic), gotBucket)
-	env := unmarshalEnvelope(t, kw.last.Value)
-	assert.Equal(t, "data-definitions", env.System, "stamp must match the write role")
+	envelope := unmarshalEnvelope(t, kw.last.Value)
+	assert.Equal(t, "data-definitions", envelope.System, "stamp must match the write role")
 }
 
 func TestWriter_InternalTopicStampsOwnSystem(t *testing.T) {
@@ -386,8 +386,8 @@ func TestWriter_InternalTopicStampsOwnSystem(t *testing.T) {
 	require.NoError(t, batch.Produce(context.Background()))
 
 	assert.Equal(t, "billing", gotSystem)
-	env := unmarshalEnvelope(t, kw.last.Value)
-	assert.Equal(t, "billing", env.System)
+	envelope := unmarshalEnvelope(t, kw.last.Value)
+	assert.Equal(t, "billing", envelope.System)
 }
 
 func TestWriter_WithWriterSystemOverridesBoth(t *testing.T) {
@@ -411,8 +411,8 @@ func TestWriter_WithWriterSystemOverridesBoth(t *testing.T) {
 	require.NoError(t, batch.Produce(context.Background()))
 
 	assert.Equal(t, "override-sys", gotSystem, "override must win over the resolver for the write role")
-	env := unmarshalEnvelope(t, kw.last.Value)
-	assert.Equal(t, "override-sys", env.System, "override must win over the resolver for the stamp")
+	envelope := unmarshalEnvelope(t, kw.last.Value)
+	assert.Equal(t, "override-sys", envelope.System, "override must win over the resolver for the stamp")
 }
 
 // parquetKV extracts the Parquet key-value metadata footer as a map.


### PR DESCRIPTION
- Claimcheck producer setter nå inn system i envelope. Systemet utledes fra topicnavn der `sys--` topics utledes til internt system, og alle andre utledes til `data-definitions`
- system for consumer er nå en del av envelope, som i Hafslund_happi_py.
        - Dette gjør at consumers kan ta i mot meldinger fra andre enn sitt eget system. ARN bygges fra system i Envelope istedenfor å bruke sitt eget systemnavn.
- Renamet forvirrende `env` variabel som refererte til `envelope` så den nå heter envelope istedenfor.
