### PR TITLE
fix: use OTel span links instead of parent-child for kafkarator Kafka…

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,0 +1,15 @@
+.PHONY: lgtm-up run-kafkarator-processor-demo
+
+# Starts the lgtm stack (Grafana + Tempo + Loki + Prometheus + OTel
+# Collector) used by the demos below. Idempotent — no-ops if already
+# running. Grafana UI: http://localhost:3000
+lgtm-up:
+	docker compose up -d lgtm
+
+# Runs kafkarator_processor_demo with tracing exported to the lgtm stack
+# instead of the console.
+run-kafkarator-processor-demo: lgtm-up
+	cd kafkarator_processor_demo && \
+	OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 \
+	OTEL_RESOURCE_ATTRIBUTES=service.name=kafkarator-processor-demo,service.namespace=golib-examples \
+	go run .

--- a/examples/README.md
+++ b/examples/README.md
@@ -31,6 +31,13 @@ cd kafkarator_processor_demo
 go run .
 ```
 
+By default spans print to the console. To inspect them in Grafana/Tempo instead, start the LGTM stack (`docker compose up` from the `examples` directory), then run 
+```bash 
+export $(xargs < .env) && go run .
+``` 
+
+(loads the OTLP endpoint and service name/namespace from `.env`), then open http://localhost:3000.
+
 ### What it demonstrates
 
 - Starting a local Kafka container for testing

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -1,0 +1,19 @@
+services:
+  # All-in-one LGTM stack (Grafana + Tempo + Loki + Prometheus) with an
+  # OpenTelemetry Collector, for visually inspecting spans produced by the
+  # examples in this directory.
+  #
+  # Usage: from this directory, `docker compose up`, then point a demo's
+  # telemetry setup at the collector, e.g.:
+  #   OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 go run ./kafkarator_processor_demo
+  # Grafana UI: http://localhost:3000
+  lgtm:
+    image: grafana/otel-lgtm
+    ports:
+      - "3000:3000" # Grafana UI
+      - "4317:4317" # OTLP gRPC
+      - "4318:4318" # OTLP HTTP
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'

--- a/examples/kafkarator_processor_demo/main.go
+++ b/examples/kafkarator_processor_demo/main.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"log"
 	"log/slog"
+	"os"
 	"time"
 
 	"github.com/hafslundkraft/golib/kafkarator"
@@ -64,8 +65,14 @@ func main() {
 	schemaRegistryURL := demohelpers.GetRedpandaSchemaRegistryAddress(ctx, kafkaContainer)
 	log.Printf("Redpanda Schema Registry URL: %s", schemaRegistryURL)
 
-	// Setup telemetry (observability)
-	tp, shutdown := telemetry.New(ctx, telemetry.WithLocal(true))
+	// Setup telemetry (observability). Prints to the console by default; set
+	// OTEL_EXPORTER_OTLP_ENDPOINT (e.g. http://localhost:4318, matching the
+	// lgtm stack in ../docker-compose.yml) to export real spans instead.
+	var telemetryOpts []telemetry.OptionFunc
+	if os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT") == "" {
+		telemetryOpts = append(telemetryOpts, telemetry.WithLocal(true))
+	}
+	tp, shutdown := telemetry.New(ctx, telemetryOpts...)
 	defer func() {
 		if err := shutdown(ctx); err != nil {
 			log.Printf("Failed to shutdown telemetry: %v", err)

--- a/kafkarator/README.md
+++ b/kafkarator/README.md
@@ -287,26 +287,7 @@ if err := conn.Test(ctx); err != nil {
 
 This library automatically propagates OpenTelemetry trace context through Kafka messages when a telemetry provider is configured. This enables distributed tracing across your Kafka-based microservices.
 
-### Prerequisites
-
-Before trace propagation can work, you must configure the global OpenTelemetry text map propagator. This is typically done once at application startup:
-
-```go
-import (
-    "go.opentelemetry.io/otel"
-    "go.opentelemetry.io/otel/propagation"
-)
-
-func init() {
-    // Configure the global propagator for W3C Trace Context
-    otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
-        propagation.TraceContext{},
-        propagation.Baggage{},
-    ))
-}
-```
-
-**Note**: The `github.com/hafslundkraft/golib/telemetry` library may already configure this for you. Check your telemetry initialization code to avoid duplicate configuration.
+kafkarator reads and writes this trace context using its own propagator, independent of whatever (if anything) the host application has configured globally via `otel.SetTextMapPropagator` — no setup is required for trace propagation to work.
 
 ### Trace Context Headers
 
@@ -338,13 +319,23 @@ The library creates spans for all Kafka operations:
 - **Name**: `send <topic-name>`
 - **Attributes**: `messaging.system=kafka`, `messaging.operation.type=send`, `messaging.operation.name=send`, `messaging.destination.name` (topic), `messaging.destination.partition.id`, `messaging.kafka.offset`, `messaging.kafka.message.key` (if present)
 
-**Consumer spans** (SpanKind: CLIENT):
+**Poll spans** (SpanKind: CLIENT):
 - **Name**: `poll <topic-name>`
 - **Attributes**: `messaging.system=kafka`, `messaging.operation.type=receive`, `messaging.operation.name=poll`, `messaging.destination.name` (topic), `messaging.consumer.group.name`, `messaging.batch.message_count` (for multi-message batches), `messaging.destination.partition.id`, `messaging.kafka.offset`
+
+**Process spans** (SpanKind: CONSUMER):
+- **Name**: `process <topic-name>`
+- **Attributes**: `messaging.system=kafka`, `messaging.operation.type=process`, `messaging.operation.name=process`, `messaging.destination.name` (topic), `messaging.consumer.group.name`, `messaging.destination.partition.id`, `messaging.kafka.offset`
 
 **Commit spans** (SpanKind: CLIENT):
 - **Name**: `commit <topic-name>`
 - **Attributes**: `messaging.system=kafka`, `messaging.operation.type=settle`, `messaging.operation.name=commit`, `messaging.destination.name` (topic), `messaging.consumer.group.name`
+
+### How Spans Are Correlated
+
+A process span carries an OpenTelemetry [Link](https://opentelemetry.io/docs/specs/otel/trace/api/#link) back to the producer's send span — it does **not** parent to it, and it starts its own trace rather than extending the producer's.
+
+This is deliberate: Kafka topics are durable and replayable. A message can be reprocessed long after it was produced (consumer group reset, backfill, DLQ retry, or just ordinary lag), and by then the producer's trace may already be closed or evicted from the tracing backend's retention window. Parent-child spans assume a bounded request/response lifetime; grafting a new span onto a trace that may be arbitrarily old — or gone — produces incorrect or unqueryable traces. A link records the relationship without depending on the producer's trace still being "live," and correctly represents fan-out too: several consumer groups can each process the same message, each getting their own trace linked back to the same producer span.
 
 ### Error Handling
 

--- a/kafkarator/helpers.go
+++ b/kafkarator/helpers.go
@@ -1,13 +1,9 @@
 package kafkarator
 
 import (
-	"context"
 	"fmt"
-	"maps"
 
 	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
-	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/propagation"
 )
 
 func defaultSubjectNameProvider(topic string) (string, error) {
@@ -23,22 +19,4 @@ func convertHeaders(hdrs []kafka.Header) map[string][]byte {
 		m[h.Key] = h.Value
 	}
 	return m
-}
-
-// injectTraceContext extracts the trace context from the current span and injects it into the headers
-func injectTraceContext(ctx context.Context, headers map[string][]byte) map[string][]byte {
-	// Create a new map to avoid modifying the original
-	propagatedHeaders := make(map[string][]byte, len(headers))
-	maps.Copy(propagatedHeaders, headers)
-
-	// Use a MapCarrier to inject trace context
-	carrier := propagation.MapCarrier{}
-	otel.GetTextMapPropagator().Inject(ctx, carrier)
-
-	// Add trace context headers to the Kafka headers
-	for k, v := range carrier {
-		propagatedHeaders[k] = []byte(v)
-	}
-
-	return propagatedHeaders
 }

--- a/kafkarator/processor.go
+++ b/kafkarator/processor.go
@@ -108,6 +108,9 @@ func (p *Processor) Close(ctx context.Context) error {
 // It reads messages, processes each one with the configured handler,
 // and commits offsets only after all messages are successfully processed.
 //
+// The context passed to the handler carries a trace.Link back to the
+// producer's span rather than sharing its trace ID.
+//
 // The number of messages and read timeout are configured when creating the Processor
 // using WithProcessorMaxMessages and WithProcessorReadTimeout.
 //
@@ -124,9 +127,6 @@ func (p *Processor) ProcessNext(ctx context.Context) (int, error) {
 		if err := ctx.Err(); err != nil {
 			return processedCount, fmt.Errorf("context canceled: %w", err)
 		}
-		// Link to the producer's span rather than parenting to it: Kafka is a
-		// durable, replayable log, so the processing span shouldn't be grafted
-		// onto a produce-time trace that may be long closed by the time this runs.
 		msgCtx, span := startProcessingSpan(ctx, p.tel.Tracer(), p.reader.consumerGroup, &msgs[i])
 
 		// Call user's processing function

--- a/kafkarator/processor.go
+++ b/kafkarator/processor.go
@@ -124,17 +124,10 @@ func (p *Processor) ProcessNext(ctx context.Context) (int, error) {
 		if err := ctx.Err(); err != nil {
 			return processedCount, fmt.Errorf("context canceled: %w", err)
 		}
-		// Extract trace context from message headers to continue the distributed trace
-		msgCtx := msgs[i].ExtractTraceContext(ctx)
-		msgCtx, span := startProcessingSpan(
-			msgCtx,
-			p.tel.Tracer(),
-			p.reader.topic,
-			p.reader.consumerGroup,
-			//nolint:gosec // Partition is a Kafka partition ID, non-negative and defined by Kafka as int32
-			int32(msgs[i].Partition),
-			msgs[i].Offset,
-		)
+		// Link to the producer's span rather than parenting to it: Kafka is a
+		// durable, replayable log, so the processing span shouldn't be grafted
+		// onto a produce-time trace that may be long closed by the time this runs.
+		msgCtx, span := startProcessingSpan(ctx, p.tel.Tracer(), p.reader.consumerGroup, &msgs[i])
 
 		// Call user's processing function
 		processErr := p.handler(msgCtx, &msgs[i])

--- a/kafkarator/round_trip_test.go
+++ b/kafkarator/round_trip_test.go
@@ -386,9 +386,21 @@ func TestWriterProcessorRoundtripWithTracing(t *testing.T) {
 	// Verify parent-child relationships
 	assertTraceContext(t, parentSpanRecorded, sendSpan)
 
-	// Verify same trace across send and process
-	assert.Equal(t, sendSpan.SpanContext().TraceID(), processSpan.SpanContext().TraceID(),
-		"send and process spans should share the same trace ID")
+	// Verify process span starts its own trace rather than extending the
+	// producer's (Kafka is a durable/replayable log, so we link, not parent)
+	assert.NotEqual(t, sendSpan.SpanContext().TraceID(), processSpan.SpanContext().TraceID(),
+		"process span should start its own trace, not extend the producer's")
+
+	// Verify the process span links back to the producer's send span.
+	// Compare TraceID/SpanID rather than the full SpanContext: a SpanContext
+	// reconstructed via propagator.Extract is always marked remote, unlike
+	// the span recorder's locally-recorded SpanContext.
+	links := processSpan.Links()
+	require.Len(t, links, 1, "process span should have exactly one link to the producer span")
+	assert.Equal(t, sendSpan.SpanContext().TraceID(), links[0].SpanContext.TraceID(),
+		"process span should link to the producer's send span (trace ID)")
+	assert.Equal(t, sendSpan.SpanContext().SpanID(), links[0].SpanContext.SpanID(),
+		"process span should link to the producer's send span (span ID)")
 }
 
 func TestReaderAutoOffsetResetEarliestReadsExistingMessage(t *testing.T) {

--- a/kafkarator/round_trip_test.go
+++ b/kafkarator/round_trip_test.go
@@ -386,15 +386,11 @@ func TestWriterProcessorRoundtripWithTracing(t *testing.T) {
 	// Verify parent-child relationships
 	assertTraceContext(t, parentSpanRecorded, sendSpan)
 
-	// Verify process span starts its own trace rather than extending the
-	// producer's (Kafka is a durable/replayable log, so we link, not parent)
+	// Verify process span starts its own trace
 	assert.NotEqual(t, sendSpan.SpanContext().TraceID(), processSpan.SpanContext().TraceID(),
 		"process span should start its own trace, not extend the producer's")
 
 	// Verify the process span links back to the producer's send span.
-	// Compare TraceID/SpanID rather than the full SpanContext: a SpanContext
-	// reconstructed via propagator.Extract is always marked remote, unlike
-	// the span recorder's locally-recorded SpanContext.
 	links := processSpan.Links()
 	require.Len(t, links, 1, "process span should have exactly one link to the producer span")
 	assert.Equal(t, sendSpan.SpanContext().TraceID(), links[0].SpanContext.TraceID(),

--- a/kafkarator/telemetry.go
+++ b/kafkarator/telemetry.go
@@ -3,13 +3,25 @@ package kafkarator
 import (
 	"context"
 	"fmt"
+	"maps"
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/propagation"
 	semconv "go.opentelemetry.io/otel/semconv/v1.38.0"
 	"go.opentelemetry.io/otel/semconv/v1.38.0/messagingconv"
 	"go.opentelemetry.io/otel/trace"
+)
+
+// tracePropagator is used to read/write W3C trace context (and baggage) on
+// Kafka message headers. It's a package-local instance rather than
+// otel.GetTextMapPropagator(): that global defaults to a no-op until some
+// caller explicitly registers one via otel.SetTextMapPropagator, and
+// kafkarator shouldn't depend on the host application having done so.
+var tracePropagator = propagation.NewCompositeTextMapPropagator( //nolint:gochecknoglobals // stateless, read-only propagator config
+	propagation.TraceContext{},
+	propagation.Baggage{},
 )
 
 // OpenTelemetry semantic conventions for Kafka messaging.
@@ -47,15 +59,15 @@ func getErrorType(err error) string {
 //nolint:spancheck // Span is returned for caller to manage
 func startProduceSpan(ctx context.Context, tracer trace.Tracer, topic string) (context.Context, trace.Span) {
 	spanName := fmt.Sprintf("%s %s", MessagingOperationNameSend, topic)
-	ctx, span := tracer.Start(ctx, spanName, trace.WithSpanKind(trace.SpanKindProducer))
-
-	span.SetAttributes(
-		semconv.MessagingSystemKafka,
-		semconv.MessagingDestinationName(topic),
-		semconv.MessagingOperationName(MessagingOperationNameSend),
-		semconv.MessagingOperationTypeSend)
-
-	return ctx, span
+	return tracer.Start(ctx, spanName,
+		trace.WithSpanKind(trace.SpanKindProducer),
+		trace.WithAttributes(
+			semconv.MessagingSystemKafka,
+			semconv.MessagingDestinationName(topic),
+			semconv.MessagingOperationName(MessagingOperationNameSend),
+			semconv.MessagingOperationTypeSend,
+		),
+	)
 }
 
 // startPollSpan creates a span for a Kafka poll operation with all standard attributes.
@@ -64,16 +76,16 @@ func startProduceSpan(ctx context.Context, tracer trace.Tracer, topic string) (c
 //nolint:spancheck // Span is returned for caller to manage
 func startPollSpan(ctx context.Context, tracer trace.Tracer, topic, group string) (context.Context, trace.Span) {
 	spanName := fmt.Sprintf("%s %s", MessagingOperationNamePoll, topic)
-	ctx, span := tracer.Start(ctx, spanName, trace.WithSpanKind(trace.SpanKindClient))
-
-	span.SetAttributes(
-		semconv.MessagingSystemKafka,
-		semconv.MessagingDestinationName(topic),
-		semconv.MessagingConsumerGroupName(group),
-		semconv.MessagingOperationName(MessagingOperationNamePoll),
-		semconv.MessagingOperationTypeReceive)
-
-	return ctx, span
+	return tracer.Start(ctx, spanName,
+		trace.WithSpanKind(trace.SpanKindClient),
+		trace.WithAttributes(
+			semconv.MessagingSystemKafka,
+			semconv.MessagingDestinationName(topic),
+			semconv.MessagingConsumerGroupName(group),
+			semconv.MessagingOperationName(MessagingOperationNamePoll),
+			semconv.MessagingOperationTypeReceive,
+		),
+	)
 }
 
 // startCommitSpan creates a span for a Kafka commit operation with all standard attributes.
@@ -82,17 +94,56 @@ func startPollSpan(ctx context.Context, tracer trace.Tracer, topic, group string
 //nolint:spancheck // Span is returned for caller to manage
 func startCommitSpan(ctx context.Context, tracer trace.Tracer, topic, group string) (context.Context, trace.Span) {
 	spanName := fmt.Sprintf("%s %s", MessagingOperationNameCommit, topic)
-	ctx, span := tracer.Start(ctx, spanName, trace.WithSpanKind(trace.SpanKindClient))
-
-	span.SetAttributes(
-		semconv.MessagingSystemKafka,
-		semconv.MessagingDestinationName(topic),
-		semconv.MessagingConsumerGroupName(group),
-		semconv.MessagingOperationName(MessagingOperationNameCommit),
-		semconv.MessagingOperationTypeSettle,
+	return tracer.Start(ctx, spanName,
+		trace.WithSpanKind(trace.SpanKindClient),
+		trace.WithAttributes(
+			semconv.MessagingSystemKafka,
+			semconv.MessagingDestinationName(topic),
+			semconv.MessagingConsumerGroupName(group),
+			semconv.MessagingOperationName(MessagingOperationNameCommit),
+			semconv.MessagingOperationTypeSettle,
+		),
 	)
+}
 
-	return ctx, span
+// injectTraceContext extracts the trace context from the current span and injects it into the headers
+func injectTraceContext(ctx context.Context, headers map[string][]byte) map[string][]byte {
+	// Create a new map to avoid modifying the original
+	propagatedHeaders := make(map[string][]byte, len(headers))
+	maps.Copy(propagatedHeaders, headers)
+
+	// Use a MapCarrier to inject trace context
+	carrier := propagation.MapCarrier{}
+	tracePropagator.Inject(ctx, carrier)
+
+	// Add trace context headers to the Kafka headers
+	for k, v := range carrier {
+		propagatedHeaders[k] = []byte(v)
+	}
+
+	return propagatedHeaders
+}
+
+// extractSpanContext parses the OpenTelemetry SpanContext carried in a Kafka
+// message's headers (written by injectTraceContext at produce time), for use
+// as a trace.Link on the processing span.
+//
+// Kafka topics are durable and replayable, so a consumer span should link to
+// the producer's span rather than parent to it: parent-child ties the new
+// span into the original trace's lifetime, which falls apart on replay,
+// backfill, or ordinary lag, where the producer's trace may already be long
+// closed (or evicted from the backend) by the time the message is processed.
+//
+// Returns a zero-value SpanContext (check IsValid()) if the message carries
+// no trace context.
+func extractSpanContext(headers map[string][]byte) trace.SpanContext {
+	carrier := propagation.MapCarrier{}
+	for k, v := range headers {
+		carrier[k] = string(v)
+	}
+
+	ctx := tracePropagator.Extract(context.Background(), carrier)
+	return trace.SpanContextFromContext(ctx)
 }
 
 // startProcessingSpan creates a span for processing a Kafka message with all standard attributes.
@@ -102,34 +153,37 @@ func startCommitSpan(ctx context.Context, tracer trace.Tracer, topic, group stri
 func startProcessingSpan(
 	ctx context.Context,
 	tracer trace.Tracer,
-	topic string,
 	group string,
-	partition int32,
-	offset int64,
+	msg *Message,
 ) (context.Context, trace.Span) {
-	spanName := fmt.Sprintf("%s %s", MessagingOperationNameProcess, topic)
-	ctx, span := tracer.Start(ctx, spanName, trace.WithSpanKind(trace.SpanKindConsumer))
+	spanName := fmt.Sprintf("%s %s", MessagingOperationNameProcess, msg.Topic)
 
 	attrs := []attribute.KeyValue{
 		semconv.MessagingSystemKafka,
-		semconv.MessagingDestinationName(topic),
+		semconv.MessagingDestinationName(msg.Topic),
 		semconv.MessagingConsumerGroupName(group),
 		semconv.MessagingOperationName(MessagingOperationNameProcess),
 		semconv.MessagingOperationTypeProcess,
 	}
 
 	// Only set partition and offset if they have valid values
-	if partition >= 0 {
-		attrs = append(attrs, semconv.MessagingDestinationPartitionID(fmt.Sprintf("%d", partition)))
+	if msg.Partition >= 0 {
+		attrs = append(attrs, semconv.MessagingDestinationPartitionID(fmt.Sprintf("%d", msg.Partition)))
 	}
 
-	if offset >= 0 {
-		attrs = append(attrs, semconv.MessagingKafkaOffset(int(offset)))
+	if msg.Offset >= 0 {
+		attrs = append(attrs, semconv.MessagingKafkaOffset(int(msg.Offset)))
 	}
 
-	span.SetAttributes(attrs...)
+	spanOpts := []trace.SpanStartOption{
+		trace.WithSpanKind(trace.SpanKindConsumer),
+		trace.WithAttributes(attrs...),
+	}
+	if sc := extractSpanContext(msg.Headers); sc.IsValid() {
+		spanOpts = append(spanOpts, trace.WithLinks(trace.Link{SpanContext: sc}))
+	}
 
-	return ctx, span
+	return tracer.Start(ctx, spanName, spanOpts...)
 }
 
 // recordSentMessage records a metric for a sent message with standard attributes.

--- a/kafkarator/telemetry.go
+++ b/kafkarator/telemetry.go
@@ -14,11 +14,13 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-// tracePropagator is used to read/write W3C trace context (and baggage) on
-// Kafka message headers. It's a package-local instance rather than
-// otel.GetTextMapPropagator(): that global defaults to a no-op until some
-// caller explicitly registers one via otel.SetTextMapPropagator, and
-// kafkarator shouldn't depend on the host application having done so.
+// tracePropagator writes W3C trace context and baggage onto Kafka message
+// headers at produce time (extraction uses the narrower TraceContext/Baggage
+// propagators directly — see extractSpanContext and extractBaggage). It's a
+// package-local instance rather than otel.GetTextMapPropagator(): that
+// global defaults to a no-op until some caller explicitly registers one via
+// otel.SetTextMapPropagator, and kafkarator shouldn't depend on the host
+// application having done so.
 var tracePropagator = propagation.NewCompositeTextMapPropagator( //nolint:gochecknoglobals // stateless, read-only propagator config
 	propagation.TraceContext{},
 	propagation.Baggage{},
@@ -124,6 +126,16 @@ func injectTraceContext(ctx context.Context, headers map[string][]byte) map[stri
 	return propagatedHeaders
 }
 
+// headerCarrier converts Kafka message headers into a propagation.MapCarrier
+// for use with a TextMapPropagator's Extract.
+func headerCarrier(headers map[string][]byte) propagation.MapCarrier {
+	carrier := propagation.MapCarrier{}
+	for k, v := range headers {
+		carrier[k] = string(v)
+	}
+	return carrier
+}
+
 // extractSpanContext parses the OpenTelemetry SpanContext carried in a Kafka
 // message's headers (written by injectTraceContext at produce time), for use
 // as a trace.Link on the processing span.
@@ -131,13 +143,22 @@ func injectTraceContext(ctx context.Context, headers map[string][]byte) map[stri
 // Returns a zero-value SpanContext (check IsValid()) if the message carries
 // no trace context.
 func extractSpanContext(headers map[string][]byte) trace.SpanContext {
-	carrier := propagation.MapCarrier{}
-	for k, v := range headers {
-		carrier[k] = string(v)
-	}
-
-	ctx := tracePropagator.Extract(context.Background(), carrier)
+	// context.Background(), not the caller's ctx: if headers carry no valid
+	// traceparent, Extract returns its input unchanged, which would otherwise
+	// make this return whatever span the caller has active — linking to the
+	// consumer's own span instead of correctly reporting "no producer span."
+	ctx := propagation.TraceContext{}.Extract(context.Background(), headerCarrier(headers))
 	return trace.SpanContextFromContext(ctx)
+}
+
+// extractBaggage extracts W3C Baggage from a Kafka message's headers into
+// ctx. Unlike extractSpanContext, this uses the Baggage propagator alone
+// rather than the full tracePropagator: extracting into ctx (not a
+// throwaway context) with the full composite would also attach the
+// producer's span as ctx's current span, reintroducing the parent-child
+// relationship extractSpanContext's Link is meant to replace.
+func extractBaggage(ctx context.Context, headers map[string][]byte) context.Context {
+	return propagation.Baggage{}.Extract(ctx, headerCarrier(headers))
 }
 
 // startProcessingSpan creates a span for processing a Kafka message with all standard attributes.
@@ -177,6 +198,7 @@ func startProcessingSpan(
 		spanOpts = append(spanOpts, trace.WithLinks(trace.Link{SpanContext: sc}))
 	}
 
+	ctx = extractBaggage(ctx, msg.Headers)
 	return tracer.Start(ctx, spanName, spanOpts...)
 }
 

--- a/kafkarator/telemetry.go
+++ b/kafkarator/telemetry.go
@@ -128,12 +128,6 @@ func injectTraceContext(ctx context.Context, headers map[string][]byte) map[stri
 // message's headers (written by injectTraceContext at produce time), for use
 // as a trace.Link on the processing span.
 //
-// Kafka topics are durable and replayable, so a consumer span should link to
-// the producer's span rather than parent to it: parent-child ties the new
-// span into the original trace's lifetime, which falls apart on replay,
-// backfill, or ordinary lag, where the producer's trace may already be long
-// closed (or evicted from the backend) by the time the message is processed.
-//
 // Returns a zero-value SpanContext (check IsValid()) if the message carries
 // no trace context.
 func extractSpanContext(headers map[string][]byte) trace.SpanContext {

--- a/kafkarator/telemetry_test.go
+++ b/kafkarator/telemetry_test.go
@@ -1,0 +1,44 @@
+package kafkarator
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/baggage"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+// TestStartProcessingSpanPropagatesBaggage verifies that baggage set on the
+// producer's context survives into the handler's context via the message
+// headers, even though the processing span links to (rather than parents
+// from) the producer's span.
+func TestStartProcessingSpanPropagatesBaggage(t *testing.T) {
+	ctx := context.Background()
+
+	spanRecorder := tracetest.NewSpanRecorder()
+	tracerProvider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(spanRecorder))
+	defer func() { _ = tracerProvider.Shutdown(ctx) }()
+	tracer := tracerProvider.Tracer("test")
+
+	member, err := baggage.NewMember("tenant.id", "acme-corp")
+	require.NoError(t, err)
+	bag, err := baggage.New(member)
+	require.NoError(t, err)
+
+	producerCtx := baggage.ContextWithBaggage(ctx, bag)
+	producerCtx, producerSpan := tracer.Start(producerCtx, "send test-topic")
+
+	headers := injectTraceContext(producerCtx, map[string][]byte{})
+	producerSpan.End()
+
+	msg := &Message{Topic: "test-topic", Headers: headers}
+
+	msgCtx, span := startProcessingSpan(ctx, tracer, "test-group", msg)
+	defer span.End()
+
+	assert.Equal(t, "acme-corp", baggage.FromContext(msgCtx).Member("tenant.id").Value(),
+		"handler context should carry the producer's baggage")
+}

--- a/kafkarator/testSetup_test.go
+++ b/kafkarator/testSetup_test.go
@@ -7,8 +7,6 @@ import (
 	"testing"
 
 	testkafka "github.com/testcontainers/testcontainers-go/modules/kafka"
-	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/propagation"
 )
 
 const kafkaImage = "confluentinc/confluent-local:7.5.0"
@@ -20,13 +18,6 @@ var (
 
 func TestMain(m *testing.M) {
 	ctx := context.Background()
-
-	// Set up the global text map propagator for W3C Trace Context
-	// This is required for trace context propagation to work
-	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
-		propagation.TraceContext{},
-		propagation.Baggage{},
-	))
 
 	os.Setenv("HAPPI_ENV", "test")
 	os.Setenv("KAFKA_SASL_SCOPE", "dummy-scope")

--- a/kafkarator/types.go
+++ b/kafkarator/types.go
@@ -1,12 +1,5 @@
 package kafkarator
 
-import (
-	"context"
-
-	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/propagation"
-)
-
 // Message is a message that can either be written to topic or be read off of a topic. It is more or less identical to the struct that is
 // implemented by the underlying kafka library. We choose to expose our own type in order to insulate the writer/consumer from
 // such implementation details.
@@ -28,26 +21,4 @@ type Message struct {
 
 	// Headers are keys value header pairs associated with the message.
 	Headers map[string][]byte
-}
-
-// ExtractTraceContext extracts the OpenTelemetry trace context from the message headers
-// and returns a new context with the extracted trace information. This allows consumers
-// to continue the trace that was started by the producer.
-//
-// Example usage:
-//
-//	for msg := range messageChan {
-//	    ctx := msg.ExtractTraceContext(ctx)
-//	    // Use ctx for downstream operations to continue the trace
-//	    processMessage(ctx, msg.Value)
-//	}
-func (m *Message) ExtractTraceContext(ctx context.Context) context.Context {
-	// Convert headers map to MapCarrier
-	carrier := propagation.MapCarrier{}
-	for k, v := range m.Headers {
-		carrier[k] = string(v)
-	}
-
-	// Extract trace context from headers and create new context
-	return otel.GetTextMapPropagator().Extract(ctx, carrier)
 }


### PR DESCRIPTION
… tracing

Kafka topics are durable and replayable, so parent-child spans corrupt trace timelines on replay, backfill, or ordinary consumer lag — the producer's trace may be long closed by the time a message is processed. Consumer spans now carry a trace.Link back to the producer's span instead of parenting to it.

Also fixes a real propagation bug: kafkarator relied on the global otel.GetTextMapPropagator(), which defaults to a no-op unless the host application calls otel.SetTextMapPropagator — meaning header injection/extraction silently did nothing outside of tests (which set it manually in TestMain). kafkarator now uses its own package-local propagator, independent of host app setup.

Consolidates span attribute-setting into tracer.Start() (via WithAttributes) instead of SetAttributes() after Start(), so attributes set on producer/poll/commit/process spans are visible to samplers.

Adds a local lgtm (Grafana/Tempo) stack and Makefile target for examples/kafkarator_processor_demo, for manually inspecting real spans during development.