### PR TITLE
feat(kafkarator): align Kafka telemetry with OTel messaging semconv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,9 @@ vet:
 lint:
 	$(MODEXEC) golangci-lint run --config=$(PWD)/.golangci.toml ./... \;
 
+lint-fix:
+	$(MODEXEC) golangci-lint run --fix --config=$(PWD)/.golangci.toml ./... \;	
+
 fmt:
 	$(MODEXEC) golangci-lint fmt --config=$(PWD)/.golangci.toml ./... \;
 

--- a/kafkarator/connection.go
+++ b/kafkarator/connection.go
@@ -16,11 +16,6 @@ import (
 	"github.com/hafslundkraft/golib/kafkarator/internal/auth"
 )
 
-const (
-	// Custom metrics not in semconv
-	meterPollFailures = "messaging.client.poll.failures"
-)
-
 // Connection represents a Connection to a Kafka service. Connection supports both writing
 // and reading messages. For reading, a consumer group must be supplied. This means
 // that multiple copies of the service using this library can be started simultaneously, and Kafka
@@ -184,7 +179,16 @@ func (c *Connection) Writer() (*Writer, error) {
 		return nil, fmt.Errorf("create sent messages counter: %w", err)
 	}
 
-	return newWriter(p, counter, c.tel), nil
+	opDuration, err := messagingconv.NewClientOperationDuration(
+		c.tel.Meter(),
+		metric.WithExplicitBucketBoundaries(messagingDurationBuckets...),
+	)
+	if err != nil {
+		p.Close()
+		return nil, fmt.Errorf("create operation duration histogram: %w", err)
+	}
+
+	return newWriter(p, counter, opDuration, parseServerInfo(c.config.Broker), c.tel), nil
 }
 
 // Deserializer returns a deserializer for deserializing Avro bytes to Go objects
@@ -285,13 +289,16 @@ func (c *Connection) Reader(topic string, opts ...ReaderOption) (*Reader, error)
 		return nil, fmt.Errorf("create consumed messages counter: %w", err)
 	}
 
-	failureCounter, err := c.tel.Meter().Int64Counter(meterPollFailures)
+	opDuration, err := messagingconv.NewClientOperationDuration(
+		c.tel.Meter(),
+		metric.WithExplicitBucketBoundaries(messagingDurationBuckets...),
+	)
 	if err != nil {
 		_ = consumer.Close()
-		return nil, fmt.Errorf("create meter counter %q: %w", meterPollFailures, err)
+		return nil, fmt.Errorf("create operation duration histogram: %w", err)
 	}
 
-	r, err := newReader(consumer, counter, failureCounter, c.tel, topic, group)
+	r, err := newReader(consumer, counter, opDuration, parseServerInfo(c.config.Broker), c.tel, topic, group)
 	if err != nil {
 		return nil, err
 	}
@@ -332,7 +339,17 @@ func (c *Connection) Processor(
 	if err != nil {
 		return nil, fmt.Errorf("creating reader: %w", err)
 	}
-	return newProcessor(reader, c.tel, handler, cfg.readTimeout, cfg.maxMessages), nil
+
+	processDuration, err := messagingconv.NewProcessDuration(
+		c.tel.Meter(),
+		metric.WithExplicitBucketBoundaries(messagingDurationBuckets...),
+	)
+	if err != nil {
+		_ = reader.Close(context.Background())
+		return nil, fmt.Errorf("create process duration histogram: %w", err)
+	}
+
+	return newProcessor(reader, c.tel, handler, cfg.readTimeout, cfg.maxMessages, processDuration), nil
 }
 
 // ChannelReader returns a channel that emits messages from the given Kafka topic.

--- a/kafkarator/processor.go
+++ b/kafkarator/processor.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/semconv/v1.38.0/messagingconv"
 )
 
@@ -143,11 +142,10 @@ func (p *Processor) ProcessNext(ctx context.Context) (int, error) {
 			time.Since(procStart).Seconds(),
 			processErr,
 		)
+		setSpanStatus(span, processErr)
+		span.End()
 
-		// Set span status based on processing result
 		if processErr != nil {
-			setSpanError(span, processErr)
-			span.End()
 			return processedCount, fmt.Errorf(
 				"process message (partition=%d, offset=%d): %w",
 				msgs[i].Partition,
@@ -156,8 +154,6 @@ func (p *Processor) ProcessNext(ctx context.Context) (int, error) {
 			)
 		}
 
-		span.SetStatus(codes.Ok, "message processed successfully")
-		span.End()
 		processedCount++
 	}
 

--- a/kafkarator/processor.go
+++ b/kafkarator/processor.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/semconv/v1.38.0/messagingconv"
 )
 
 // Processor provides automatic processing of Kafka messages with built-in
@@ -18,6 +19,7 @@ type Processor struct {
 	handler            ProcessFunc
 	defaultReadTimeout time.Duration
 	defaultMaxMessages int
+	processDuration    messagingconv.ProcessDuration
 }
 
 // ProcessFunc is a function that processes a single Kafka message.
@@ -89,6 +91,7 @@ func newProcessor(
 	handler ProcessFunc,
 	readTimeout time.Duration,
 	maxMessages int,
+	processDuration messagingconv.ProcessDuration,
 ) *Processor {
 	return &Processor{
 		reader:             reader,
@@ -96,6 +99,7 @@ func newProcessor(
 		handler:            handler,
 		defaultReadTimeout: readTimeout,
 		defaultMaxMessages: maxMessages,
+		processDuration:    processDuration,
 	}
 }
 
@@ -127,15 +131,22 @@ func (p *Processor) ProcessNext(ctx context.Context) (int, error) {
 		if err := ctx.Err(); err != nil {
 			return processedCount, fmt.Errorf("context canceled: %w", err)
 		}
-		msgCtx, span := startProcessingSpan(ctx, p.tel.Tracer(), p.reader.consumerGroup, &msgs[i])
+		msgCtx, span := startProcessingSpan(ctx, p.tel.Tracer(), p.reader.consumerGroup, &msgs[i], p.reader.srv)
 
 		// Call user's processing function
+		procStart := time.Now()
 		processErr := p.handler(msgCtx, &msgs[i])
+		p.recordProcess(
+			ctx,
+			msgs[i].Topic,
+			fmt.Sprintf("%d", msgs[i].Partition),
+			time.Since(procStart).Seconds(),
+			processErr,
+		)
 
 		// Set span status based on processing result
 		if processErr != nil {
-			span.RecordError(processErr)
-			span.SetStatus(codes.Error, processErr.Error())
+			setSpanError(span, processErr)
 			span.End()
 			return processedCount, fmt.Errorf(
 				"process message (partition=%d, offset=%d): %w",
@@ -156,4 +167,19 @@ func (p *Processor) ProcessNext(ctx context.Context) (int, error) {
 	}
 
 	return processedCount, nil
+}
+
+// recordProcess records messaging.process.duration for handling one delivered
+// message.
+func (p *Processor) recordProcess(ctx context.Context, topic, partition string, seconds float64, err error) {
+	recordProcessDuration(
+		ctx,
+		p.processDuration,
+		topic,
+		p.reader.consumerGroup,
+		partition,
+		p.reader.srv,
+		seconds,
+		err,
+	)
 }

--- a/kafkarator/reader.go
+++ b/kafkarator/reader.go
@@ -87,13 +87,16 @@ func (rc *Reader) Read(
 	// error — so the metric mirrors the span duration in all cases.
 	readStart := time.Now()
 	var pollErr error
+	msgs := make([]Message, 0, maxMessages)
+	// Always stamp batch attrs (plus duration/status), even when the read fails
+	// mid-batch, with the messages collected so far.
 	defer func() {
+		setPollSpanAttrs(span, msgs)
 		rc.recordReceiveDuration(ctx, time.Since(readStart).Seconds(), pollErr)
 		setSpanStatus(span, pollErr)
 	}()
 
 	deadline := time.Now().Add(maxWait)
-	msgs := make([]Message, 0, maxMessages)
 
 	// Track last seen offsets per partition
 	latestOffsets := map[int32]kafka.Offset{}
@@ -165,8 +168,6 @@ func (rc *Reader) Read(
 			// ignore rebalance events etc.
 		}
 	}
-
-	setPollSpanAttrs(span, msgs)
 
 	return msgs, commit, nil
 }

--- a/kafkarator/reader.go
+++ b/kafkarator/reader.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
-	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/semconv/v1.38.0/messagingconv"
 )
 
@@ -90,6 +89,7 @@ func (rc *Reader) Read(
 	var pollErr error
 	defer func() {
 		rc.recordReceiveDuration(ctx, time.Since(readStart).Seconds(), pollErr)
+		setSpanStatus(span, pollErr)
 	}()
 
 	deadline := time.Now().Add(maxWait)
@@ -106,6 +106,7 @@ func (rc *Reader) Read(
 		var commitErr error
 		defer func() {
 			rc.recordCommitDuration(ctx, time.Since(commitStart).Seconds(), commitErr)
+			setSpanStatus(span, commitErr)
 		}()
 
 		for partition, off := range latestOffsets {
@@ -118,12 +119,10 @@ func (rc *Reader) Read(
 			})
 			if err != nil {
 				commitErr = err
-				setSpanError(span, err)
 				return fmt.Errorf("commit failed: %w", err)
 			}
 		}
 
-		span.SetStatus(codes.Ok, "offsets committed")
 		return nil
 	})
 
@@ -155,7 +154,6 @@ func (rc *Reader) Read(
 			rc.recordConsumed(ctx, partitionID, nil)
 
 		case kafka.Error:
-			setPollError(span, e, e.IsTimeout())
 			if e.IsTimeout() {
 				return msgs, commit, nil
 			}
@@ -168,28 +166,7 @@ func (rc *Reader) Read(
 		}
 	}
 
-	if len(msgs) > 0 {
-		// Check if all messages are from the same partition
-		firstPartition := msgs[0].Partition
-		samePartition := true
-		for _, msg := range msgs[1:] {
-			if msg.Partition != firstPartition {
-				samePartition = false
-				break
-			}
-		}
-
-		if samePartition {
-			// Single partition: include partition and offset details
-			partitionID := fmt.Sprintf("%d", firstPartition)
-			setPollSuccess(span, len(msgs), partitionID, msgs[0].Offset)
-		} else {
-			// Multiple partitions: only include batch count
-			setPollSuccess(span, len(msgs), "", 0)
-		}
-	} else {
-		setPollSuccess(span, 0, "", 0)
-	}
+	setPollSpanAttrs(span, msgs)
 
 	return msgs, commit, nil
 }

--- a/kafkarator/reader.go
+++ b/kafkarator/reader.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
 	"go.opentelemetry.io/otel/codes"
-	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/semconv/v1.38.0/messagingconv"
 )
 
@@ -20,7 +19,8 @@ type CommitFunc func(ctx context.Context) error
 func newReader(
 	c *kafka.Consumer,
 	rmc messagingconv.ClientConsumedMessages,
-	pfc metric.Int64Counter,
+	opDur messagingconv.ClientOperationDuration,
+	srv serverInfo,
 	tel TelemetryProvider,
 	topic string,
 	consumerGroup string,
@@ -28,7 +28,8 @@ func newReader(
 	r := &Reader{
 		consumer:            c,
 		readMessagesCounter: rmc,
-		pollFailuresCounter: pfc,
+		operationDuration:   opDur,
+		srv:                 srv,
 		tel:                 tel,
 		topic:               topic,
 		consumerGroup:       consumerGroup,
@@ -45,7 +46,8 @@ func newReader(
 type Reader struct {
 	consumer            *kafka.Consumer
 	readMessagesCounter messagingconv.ClientConsumedMessages
-	pollFailuresCounter metric.Int64Counter
+	operationDuration   messagingconv.ClientOperationDuration
+	srv                 serverInfo
 	tel                 TelemetryProvider
 	closed              bool
 	topic               string
@@ -78,8 +80,17 @@ func (rc *Reader) Read(
 	maxMessages int,
 	maxWait time.Duration,
 ) ([]Message, CommitFunc, error) {
-	ctx, span := startPollSpan(ctx, rc.tel.Tracer(), rc.topic, rc.consumerGroup)
+	ctx, span := startPollSpan(ctx, rc.tel.Tracer(), rc.topic, rc.consumerGroup, rc.srv)
 	defer span.End()
+
+	// Record one operation.duration per receive, matching the poll span. Emitted
+	// on every read — a caught-up read that waits out maxWait is expected, not an
+	// error — so the metric mirrors the span duration in all cases.
+	readStart := time.Now()
+	var pollErr error
+	defer func() {
+		rc.recordReceiveDuration(ctx, time.Since(readStart).Seconds(), pollErr)
+	}()
 
 	deadline := time.Now().Add(maxWait)
 	msgs := make([]Message, 0, maxMessages)
@@ -88,8 +99,14 @@ func (rc *Reader) Read(
 	latestOffsets := map[int32]kafka.Offset{}
 
 	commit := CommitFunc(func(ctx context.Context) error {
-		_, span := startCommitSpan(ctx, rc.tel.Tracer(), rc.topic, rc.consumerGroup)
+		_, span := startCommitSpan(ctx, rc.tel.Tracer(), rc.topic, rc.consumerGroup, rc.srv)
 		defer span.End()
+
+		commitStart := time.Now()
+		var commitErr error
+		defer func() {
+			rc.recordCommitDuration(ctx, time.Since(commitStart).Seconds(), commitErr)
+		}()
 
 		for partition, off := range latestOffsets {
 			_, err := rc.consumer.CommitOffsets([]kafka.TopicPartition{
@@ -100,8 +117,8 @@ func (rc *Reader) Read(
 				},
 			})
 			if err != nil {
-				span.RecordError(err)
-				span.SetStatus(codes.Error, err.Error())
+				commitErr = err
+				setSpanError(span, err)
 				return fmt.Errorf("commit failed: %w", err)
 			}
 		}
@@ -135,14 +152,15 @@ func (rc *Reader) Read(
 
 			latestOffsets[e.TopicPartition.Partition] = e.TopicPartition.Offset
 			partitionID := fmt.Sprintf("%d", e.TopicPartition.Partition)
-			recordConsumedMessage(ctx, rc.readMessagesCounter, rc.topic, rc.consumerGroup, partitionID, nil)
+			rc.recordConsumed(ctx, partitionID, nil)
 
 		case kafka.Error:
 			setPollError(span, e, e.IsTimeout())
 			if e.IsTimeout() {
 				return msgs, commit, nil
 			}
-			recordPollFailure(ctx, rc.pollFailuresCounter, rc.topic, rc.consumerGroup, e)
+			rc.recordConsumed(ctx, "", e)
+			pollErr = e
 			return msgs, commit, fmt.Errorf("poll error: %w", e)
 
 		default:
@@ -174,4 +192,44 @@ func (rc *Reader) Read(
 	}
 
 	return msgs, commit, nil
+}
+
+// recordReceiveDuration records messaging.client.operation.duration for a
+// poll/receive covering the whole Read.
+func (rc *Reader) recordReceiveDuration(ctx context.Context, seconds float64, err error) {
+	recordOperationDuration(
+		ctx,
+		rc.operationDuration,
+		MessagingOperationNamePoll,
+		messagingconv.OperationTypeReceive,
+		rc.topic,
+		rc.consumerGroup,
+		"",
+		rc.srv,
+		seconds,
+		err,
+	)
+}
+
+// recordCommitDuration records messaging.client.operation.duration for an
+// offset commit (settle).
+func (rc *Reader) recordCommitDuration(ctx context.Context, seconds float64, err error) {
+	recordOperationDuration(
+		ctx,
+		rc.operationDuration,
+		MessagingOperationNameCommit,
+		messagingconv.OperationTypeSettle,
+		rc.topic,
+		rc.consumerGroup,
+		"",
+		rc.srv,
+		seconds,
+		err,
+	)
+}
+
+// recordConsumed records one messaging.client.consumed.messages for a delivered
+// message, or a failed receive when err is non-nil.
+func (rc *Reader) recordConsumed(ctx context.Context, partition string, err error) {
+	recordConsumedMessage(ctx, rc.readMessagesCounter, rc.topic, rc.consumerGroup, partition, rc.srv, err)
 }

--- a/kafkarator/telemetry.go
+++ b/kafkarator/telemetry.go
@@ -116,14 +116,20 @@ func getErrorType(err error) string {
 // Caller must call span.End() when the operation completes.
 //
 //nolint:spancheck // Span is returned for caller to manage
-func startProduceSpan(ctx context.Context, tracer trace.Tracer, topic string, srv serverInfo) (context.Context, trace.Span) {
+func startProduceSpan(
+	ctx context.Context,
+	tracer trace.Tracer,
+	topic string,
+	srv serverInfo,
+) (context.Context, trace.Span) {
 	spanName := fmt.Sprintf("%s %s", MessagingOperationNameSend, topic)
-	attrs := []attribute.KeyValue{
+	attrs := make([]attribute.KeyValue, 0, 4+len(srv.spanAttrs()))
+	attrs = append(attrs,
 		semconv.MessagingSystemKafka,
 		semconv.MessagingDestinationName(topic),
 		semconv.MessagingOperationName(MessagingOperationNameSend),
 		semconv.MessagingOperationTypeSend,
-	}
+	)
 	attrs = append(attrs, srv.spanAttrs()...)
 	return tracer.Start(ctx, spanName,
 		trace.WithSpanKind(trace.SpanKindProducer),
@@ -135,15 +141,21 @@ func startProduceSpan(ctx context.Context, tracer trace.Tracer, topic string, sr
 // Caller must call span.End() when the operation completes.
 //
 //nolint:spancheck // Span is returned for caller to manage
-func startPollSpan(ctx context.Context, tracer trace.Tracer, topic, group string, srv serverInfo) (context.Context, trace.Span) {
+func startPollSpan(
+	ctx context.Context,
+	tracer trace.Tracer,
+	topic, group string,
+	srv serverInfo,
+) (context.Context, trace.Span) {
 	spanName := fmt.Sprintf("%s %s", MessagingOperationNamePoll, topic)
-	attrs := []attribute.KeyValue{
+	attrs := make([]attribute.KeyValue, 0, 5+len(srv.spanAttrs()))
+	attrs = append(attrs,
 		semconv.MessagingSystemKafka,
 		semconv.MessagingDestinationName(topic),
 		semconv.MessagingConsumerGroupName(group),
 		semconv.MessagingOperationName(MessagingOperationNamePoll),
 		semconv.MessagingOperationTypeReceive,
-	}
+	)
 	attrs = append(attrs, srv.spanAttrs()...)
 	return tracer.Start(ctx, spanName,
 		trace.WithSpanKind(trace.SpanKindClient),
@@ -155,15 +167,21 @@ func startPollSpan(ctx context.Context, tracer trace.Tracer, topic, group string
 // Caller must call span.End() when the operation completes.
 //
 //nolint:spancheck // Span is returned for caller to manage
-func startCommitSpan(ctx context.Context, tracer trace.Tracer, topic, group string, srv serverInfo) (context.Context, trace.Span) {
+func startCommitSpan(
+	ctx context.Context,
+	tracer trace.Tracer,
+	topic, group string,
+	srv serverInfo,
+) (context.Context, trace.Span) {
 	spanName := fmt.Sprintf("%s %s", MessagingOperationNameCommit, topic)
-	attrs := []attribute.KeyValue{
+	attrs := make([]attribute.KeyValue, 0, 5+len(srv.spanAttrs()))
+	attrs = append(attrs,
 		semconv.MessagingSystemKafka,
 		semconv.MessagingDestinationName(topic),
 		semconv.MessagingConsumerGroupName(group),
 		semconv.MessagingOperationName(MessagingOperationNameCommit),
 		semconv.MessagingOperationTypeSettle,
-	}
+	)
 	attrs = append(attrs, srv.spanAttrs()...)
 	return tracer.Start(ctx, spanName,
 		trace.WithSpanKind(trace.SpanKindClient),

--- a/kafkarator/telemetry.go
+++ b/kafkarator/telemetry.go
@@ -2,12 +2,16 @@ package kafkarator
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"maps"
+	"net"
+	"strconv"
+	"strings"
 
+	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
-	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/propagation"
 	semconv "go.opentelemetry.io/otel/semconv/v1.38.0"
 	"go.opentelemetry.io/otel/semconv/v1.38.0/messagingconv"
@@ -39,6 +43,57 @@ const (
 	DefaultErrorType = "_OTHER"
 )
 
+// messagingDurationBuckets is the ExplicitBucketBoundaries advisory the
+// messaging semantic conventions specify for the duration histograms
+// (messaging.client.operation.duration, messaging.process.duration). The
+// generated messagingconv constructors omit it, so it's passed at instrument
+// creation; without it the SDK defaults to buckets tuned for a 0–10000 range,
+// which are useless for second-scale durations.
+var messagingDurationBuckets = []float64{ //nolint:gochecknoglobals // static semconv advisory
+	0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10,
+}
+
+// serverInfo is the parsed broker endpoint recorded as server.address /
+// server.port on spans and metrics. The zero value (empty address) means
+// "unknown" and the attributes are omitted.
+type serverInfo struct {
+	address string
+	port    int
+}
+
+// parseServerInfo extracts server.address/server.port from a configured broker
+// string. The broker may be comma-separated; the first endpoint is used (the
+// client-facing endpoint is the same regardless of how many nodes back it).
+func parseServerInfo(broker string) serverInfo {
+	first := strings.TrimSpace(strings.SplitN(broker, ",", 2)[0])
+	if first == "" {
+		return serverInfo{}
+	}
+	host, port, err := net.SplitHostPort(first)
+	if err != nil {
+		// No parseable port — use the whole value as the address.
+		return serverInfo{address: first}
+	}
+	p, err := strconv.Atoi(port)
+	if err != nil {
+		return serverInfo{address: host}
+	}
+	return serverInfo{address: host, port: p}
+}
+
+// spanAttrs returns the server.address/server.port span attributes, or nil when
+// the broker endpoint is unknown.
+func (s serverInfo) spanAttrs() []attribute.KeyValue {
+	if s.address == "" {
+		return nil
+	}
+	attrs := []attribute.KeyValue{semconv.ServerAddress(s.address)}
+	if s.port > 0 {
+		attrs = append(attrs, semconv.ServerPort(s.port))
+	}
+	return attrs
+}
+
 // getErrorType extracts a low-cardinality error type from an error.
 // For Kafka errors, it returns the error code. For other errors, it returns a generic type.
 func getErrorType(err error) string {
@@ -46,8 +101,10 @@ func getErrorType(err error) string {
 		return ""
 	}
 
-	// Check if it's a Kafka error with a code
-	if ke, ok := err.(interface{ Code() int }); ok {
+	// Kafka errors carry a broker/client code; surface it as a low-cardinality
+	// error.type. errors.As unwraps fmt.Errorf(%w) chains.
+	var ke kafka.Error
+	if errors.As(err, &ke) {
 		return fmt.Sprintf("kafka_error_%d", ke.Code())
 	}
 
@@ -59,16 +116,18 @@ func getErrorType(err error) string {
 // Caller must call span.End() when the operation completes.
 //
 //nolint:spancheck // Span is returned for caller to manage
-func startProduceSpan(ctx context.Context, tracer trace.Tracer, topic string) (context.Context, trace.Span) {
+func startProduceSpan(ctx context.Context, tracer trace.Tracer, topic string, srv serverInfo) (context.Context, trace.Span) {
 	spanName := fmt.Sprintf("%s %s", MessagingOperationNameSend, topic)
+	attrs := []attribute.KeyValue{
+		semconv.MessagingSystemKafka,
+		semconv.MessagingDestinationName(topic),
+		semconv.MessagingOperationName(MessagingOperationNameSend),
+		semconv.MessagingOperationTypeSend,
+	}
+	attrs = append(attrs, srv.spanAttrs()...)
 	return tracer.Start(ctx, spanName,
 		trace.WithSpanKind(trace.SpanKindProducer),
-		trace.WithAttributes(
-			semconv.MessagingSystemKafka,
-			semconv.MessagingDestinationName(topic),
-			semconv.MessagingOperationName(MessagingOperationNameSend),
-			semconv.MessagingOperationTypeSend,
-		),
+		trace.WithAttributes(attrs...),
 	)
 }
 
@@ -76,17 +135,19 @@ func startProduceSpan(ctx context.Context, tracer trace.Tracer, topic string) (c
 // Caller must call span.End() when the operation completes.
 //
 //nolint:spancheck // Span is returned for caller to manage
-func startPollSpan(ctx context.Context, tracer trace.Tracer, topic, group string) (context.Context, trace.Span) {
+func startPollSpan(ctx context.Context, tracer trace.Tracer, topic, group string, srv serverInfo) (context.Context, trace.Span) {
 	spanName := fmt.Sprintf("%s %s", MessagingOperationNamePoll, topic)
+	attrs := []attribute.KeyValue{
+		semconv.MessagingSystemKafka,
+		semconv.MessagingDestinationName(topic),
+		semconv.MessagingConsumerGroupName(group),
+		semconv.MessagingOperationName(MessagingOperationNamePoll),
+		semconv.MessagingOperationTypeReceive,
+	}
+	attrs = append(attrs, srv.spanAttrs()...)
 	return tracer.Start(ctx, spanName,
 		trace.WithSpanKind(trace.SpanKindClient),
-		trace.WithAttributes(
-			semconv.MessagingSystemKafka,
-			semconv.MessagingDestinationName(topic),
-			semconv.MessagingConsumerGroupName(group),
-			semconv.MessagingOperationName(MessagingOperationNamePoll),
-			semconv.MessagingOperationTypeReceive,
-		),
+		trace.WithAttributes(attrs...),
 	)
 }
 
@@ -94,17 +155,19 @@ func startPollSpan(ctx context.Context, tracer trace.Tracer, topic, group string
 // Caller must call span.End() when the operation completes.
 //
 //nolint:spancheck // Span is returned for caller to manage
-func startCommitSpan(ctx context.Context, tracer trace.Tracer, topic, group string) (context.Context, trace.Span) {
+func startCommitSpan(ctx context.Context, tracer trace.Tracer, topic, group string, srv serverInfo) (context.Context, trace.Span) {
 	spanName := fmt.Sprintf("%s %s", MessagingOperationNameCommit, topic)
+	attrs := []attribute.KeyValue{
+		semconv.MessagingSystemKafka,
+		semconv.MessagingDestinationName(topic),
+		semconv.MessagingConsumerGroupName(group),
+		semconv.MessagingOperationName(MessagingOperationNameCommit),
+		semconv.MessagingOperationTypeSettle,
+	}
+	attrs = append(attrs, srv.spanAttrs()...)
 	return tracer.Start(ctx, spanName,
 		trace.WithSpanKind(trace.SpanKindClient),
-		trace.WithAttributes(
-			semconv.MessagingSystemKafka,
-			semconv.MessagingDestinationName(topic),
-			semconv.MessagingConsumerGroupName(group),
-			semconv.MessagingOperationName(MessagingOperationNameCommit),
-			semconv.MessagingOperationTypeSettle,
-		),
+		trace.WithAttributes(attrs...),
 	)
 }
 
@@ -170,6 +233,7 @@ func startProcessingSpan(
 	tracer trace.Tracer,
 	group string,
 	msg *Message,
+	srv serverInfo,
 ) (context.Context, trace.Span) {
 	spanName := fmt.Sprintf("%s %s", MessagingOperationNameProcess, msg.Topic)
 
@@ -180,6 +244,7 @@ func startProcessingSpan(
 		semconv.MessagingOperationName(MessagingOperationNameProcess),
 		semconv.MessagingOperationTypeProcess,
 	}
+	attrs = append(attrs, srv.spanAttrs()...)
 
 	// Only set partition and offset if they have valid values
 	if msg.Partition >= 0 {
@@ -207,9 +272,10 @@ func recordSentMessage(
 	ctx context.Context,
 	counter messagingconv.ClientSentMessages,
 	topic, partition string,
+	srv serverInfo,
 	err error,
 ) {
-	attrs := make([]attribute.KeyValue, 0, 3)
+	attrs := make([]attribute.KeyValue, 0, 5)
 
 	if topic != "" {
 		attrs = append(attrs, counter.AttrDestinationName(topic))
@@ -217,6 +283,13 @@ func recordSentMessage(
 
 	if partition != "" {
 		attrs = append(attrs, counter.AttrDestinationPartitionID(partition))
+	}
+
+	if srv.address != "" {
+		attrs = append(attrs, counter.AttrServerAddress(srv.address))
+		if srv.port > 0 {
+			attrs = append(attrs, counter.AttrServerPort(srv.port))
+		}
 	}
 
 	if err != nil {
@@ -231,9 +304,10 @@ func recordConsumedMessage(
 	ctx context.Context,
 	counter messagingconv.ClientConsumedMessages,
 	topic, group, partition string,
+	srv serverInfo,
 	err error,
 ) {
-	attrs := make([]attribute.KeyValue, 0, 4)
+	attrs := make([]attribute.KeyValue, 0, 5)
 
 	if topic != "" {
 		attrs = append(attrs, counter.AttrDestinationName(topic))
@@ -247,6 +321,13 @@ func recordConsumedMessage(
 		attrs = append(attrs, counter.AttrDestinationPartitionID(partition))
 	}
 
+	if srv.address != "" {
+		attrs = append(attrs, counter.AttrServerAddress(srv.address))
+		if srv.port > 0 {
+			attrs = append(attrs, counter.AttrServerPort(srv.port))
+		}
+	}
+
 	if err != nil {
 		attrs = append(attrs, counter.AttrErrorType(messagingconv.ErrorTypeAttr(getErrorType(err))))
 	}
@@ -254,23 +335,83 @@ func recordConsumedMessage(
 	counter.Add(ctx, 1, MessagingOperationNamePoll, messagingconv.SystemKafka, attrs...)
 }
 
-// recordPollFailure records a metric for a poll failure with standard attributes.
-func recordPollFailure(ctx context.Context, counter metric.Int64Counter, topic, group string, err error) {
+// recordOperationDuration records the duration (seconds) of a client send or
+// receive operation with standard attributes.
+func recordOperationDuration(
+	ctx context.Context,
+	hist messagingconv.ClientOperationDuration,
+	operationName string,
+	operationType messagingconv.OperationTypeAttr,
+	topic, group, partition string,
+	srv serverInfo,
+	seconds float64,
+	err error,
+) {
 	attrs := make([]attribute.KeyValue, 0, 6)
+	attrs = append(attrs, hist.AttrOperationType(operationType))
 
-	attrs = append(attrs,
-		semconv.MessagingSystemKafka,
-		semconv.MessagingDestinationName(topic),
-		semconv.MessagingConsumerGroupName(group),
-		semconv.MessagingOperationName(MessagingOperationNamePoll),
-		semconv.MessagingOperationTypeReceive,
-	)
-
-	if err != nil {
-		attrs = append(attrs, attribute.String(string(semconv.ErrorTypeKey), getErrorType(err)))
+	if topic != "" {
+		attrs = append(attrs, hist.AttrDestinationName(topic))
 	}
 
-	counter.Add(ctx, 1, metric.WithAttributes(attrs...))
+	if group != "" {
+		attrs = append(attrs, hist.AttrConsumerGroupName(group))
+	}
+
+	if partition != "" {
+		attrs = append(attrs, hist.AttrDestinationPartitionID(partition))
+	}
+
+	if srv.address != "" {
+		attrs = append(attrs, hist.AttrServerAddress(srv.address))
+		if srv.port > 0 {
+			attrs = append(attrs, hist.AttrServerPort(srv.port))
+		}
+	}
+
+	if err != nil {
+		attrs = append(attrs, hist.AttrErrorType(messagingconv.ErrorTypeAttr(getErrorType(err))))
+	}
+
+	hist.Record(ctx, seconds, operationName, messagingconv.SystemKafka, attrs...)
+}
+
+// recordProcessDuration records the duration (seconds) of processing a delivered
+// message with standard attributes.
+func recordProcessDuration(
+	ctx context.Context,
+	hist messagingconv.ProcessDuration,
+	topic, group, partition string,
+	srv serverInfo,
+	seconds float64,
+	err error,
+) {
+	attrs := make([]attribute.KeyValue, 0, 5)
+
+	if topic != "" {
+		attrs = append(attrs, hist.AttrDestinationName(topic))
+	}
+
+	if group != "" {
+		attrs = append(attrs, hist.AttrConsumerGroupName(group))
+	}
+
+	if partition != "" {
+		attrs = append(attrs, hist.AttrDestinationPartitionID(partition))
+	}
+
+	if srv.address != "" {
+		attrs = append(attrs, hist.AttrServerAddress(srv.address))
+		if srv.port > 0 {
+			attrs = append(attrs, hist.AttrServerPort(srv.port))
+		}
+	}
+
+	if err != nil {
+		attrs = append(attrs, hist.AttrErrorType(messagingconv.ErrorTypeAttr(getErrorType(err))))
+	}
+
+	hist.Record(ctx, seconds, MessagingOperationNameProcess, messagingconv.SystemKafka, attrs...)
 }
 
 // setProducerSuccess sets span attributes and status for a successful send.
@@ -282,8 +423,9 @@ func setProducerSuccess(span trace.Span, partition string, offset int64) {
 	span.SetStatus(codes.Ok, "message sent successfully")
 }
 
-// setProducerError sets span attributes and status for a failed send.
-func setProducerError(span trace.Span, err error) {
+// setSpanError records err on the span: error status, an exception event, and
+// the error.type attribute, mirroring the metric-side error.type handling.
+func setSpanError(span trace.Span, err error) {
 	span.RecordError(err)
 	span.SetStatus(codes.Error, err.Error())
 	span.SetAttributes(attribute.String(string(semconv.ErrorTypeKey), getErrorType(err)))
@@ -299,12 +441,15 @@ func setPollSuccess(span trace.Span, messageCount int, partition string, offset 
 			attrs = append(attrs, semconv.MessagingBatchMessageCount(messageCount))
 		}
 
-		// Only set partition/offset if provided (single partition batch)
+		// partition.id may describe a single message or a same-partition batch.
 		if partition != "" {
-			attrs = append(attrs,
-				semconv.MessagingDestinationPartitionID(partition),
-				semconv.MessagingKafkaOffset(int(offset)),
-			)
+			attrs = append(attrs, semconv.MessagingDestinationPartitionID(partition))
+		}
+
+		// kafka.offset is a single-message attribute: set it only when the span
+		// describes exactly one message.
+		if messageCount == 1 {
+			attrs = append(attrs, semconv.MessagingKafkaOffset(int(offset)))
 		}
 
 		if len(attrs) > 0 {
@@ -320,9 +465,7 @@ func setPollSuccess(span trace.Span, messageCount int, partition string, offset 
 func setPollError(span trace.Span, err error, isTimeout bool) {
 	if isTimeout {
 		span.SetStatus(codes.Ok, "poll timeout")
-	} else {
-		span.RecordError(err)
-		span.SetStatus(codes.Error, err.Error())
-		span.SetAttributes(attribute.String(string(semconv.ErrorTypeKey), getErrorType(err)))
+		return
 	}
+	setSpanError(span, err)
 }

--- a/kafkarator/telemetry.go
+++ b/kafkarator/telemetry.go
@@ -432,58 +432,51 @@ func recordProcessDuration(
 	hist.Record(ctx, seconds, MessagingOperationNameProcess, messagingconv.SystemKafka, attrs...)
 }
 
-// setProducerSuccess sets span attributes and status for a successful send.
-func setProducerSuccess(span trace.Span, partition string, offset int64) {
-	span.SetAttributes(
-		semconv.MessagingDestinationPartitionID(partition),
-		semconv.MessagingKafkaOffset(int(offset)),
-	)
-	span.SetStatus(codes.Ok, "message sent successfully")
-}
-
-// setSpanError records err on the span: error status, an exception event, and
-// the error.type attribute, mirroring the metric-side error.type handling.
-func setSpanError(span trace.Span, err error) {
+// setSpanStatus records failure on a span: when err is non-nil it records the
+// error, sets Error status, and stamps the error.type attribute. On success it
+// does nothing, leaving the span status UNSET — instrumentations should not set
+// Ok (per OTel guidance and the Kafka semconv span example).
+func setSpanStatus(span trace.Span, err error) {
+	if err == nil {
+		return
+	}
 	span.RecordError(err)
 	span.SetStatus(codes.Error, err.Error())
 	span.SetAttributes(attribute.String(string(semconv.ErrorTypeKey), getErrorType(err)))
 }
 
-// setPollSuccess sets span attributes and status for successful poll.
-func setPollSuccess(span trace.Span, messageCount int, partition string, offset int64) {
-	if messageCount > 0 {
-		attrs := []attribute.KeyValue{}
-
-		// Only set batch count for actual batches (2+ messages)
-		if messageCount > 1 {
-			attrs = append(attrs, semconv.MessagingBatchMessageCount(messageCount))
-		}
-
-		// partition.id may describe a single message or a same-partition batch.
-		if partition != "" {
-			attrs = append(attrs, semconv.MessagingDestinationPartitionID(partition))
-		}
-
-		// kafka.offset is a single-message attribute: set it only when the span
-		// describes exactly one message.
-		if messageCount == 1 {
-			attrs = append(attrs, semconv.MessagingKafkaOffset(int(offset)))
-		}
-
-		if len(attrs) > 0 {
-			span.SetAttributes(attrs...)
-		}
-		span.SetStatus(codes.Ok, "messages received")
-	} else {
-		span.SetStatus(codes.Ok, "no messages available")
-	}
+// setProducerSpanAttrs sets the single-message attributes on a successful send
+// span. Status is set separately via setSpanStatus.
+func setProducerSpanAttrs(span trace.Span, partition string, offset int64) {
+	span.SetAttributes(
+		semconv.MessagingDestinationPartitionID(partition),
+		semconv.MessagingKafkaOffset(int(offset)),
+	)
 }
 
-// setPollError sets span attributes and status for failed poll.
-func setPollError(span trace.Span, err error, isTimeout bool) {
-	if isTimeout {
-		span.SetStatus(codes.Ok, "poll timeout")
-		return
+// setPollSpanAttrs sets the batch attributes on a poll span. Status is set
+// separately via setSpanStatus.
+//
+// A poll is a batching operation, so batch.message_count is always set (the
+// batch size, including 0 or 1); partition.id is set only when the whole batch
+// came from a single partition. kafka.offset is deliberately not set here: it
+// is a single-message attribute and lives on the process span.
+func setPollSpanAttrs(span trace.Span, msgs []Message) {
+	attrs := []attribute.KeyValue{
+		semconv.MessagingBatchMessageCount(len(msgs)),
 	}
-	setSpanError(span, err)
+	if len(msgs) > 0 {
+		first := msgs[0].Partition
+		samePartition := true
+		for _, m := range msgs[1:] {
+			if m.Partition != first {
+				samePartition = false
+				break
+			}
+		}
+		if samePartition {
+			attrs = append(attrs, semconv.MessagingDestinationPartitionID(fmt.Sprintf("%d", first)))
+		}
+	}
+	span.SetAttributes(attrs...)
 }

--- a/kafkarator/telemetry_test.go
+++ b/kafkarator/telemetry_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/baggage"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
@@ -41,4 +42,73 @@ func TestStartProcessingSpanPropagatesBaggage(t *testing.T) {
 
 	assert.Equal(t, "acme-corp", baggage.FromContext(msgCtx).Member("tenant.id").Value(),
 		"handler context should carry the producer's baggage")
+}
+
+// TestSetPollSpanAttrs verifies the poll span is treated as a batch span:
+// batch.message_count is always set (including 0 and 1), partition.id only when
+// the whole batch came from one partition, and kafka.offset never (it is a
+// single-message attribute that belongs on the process span).
+func TestSetPollSpanAttrs(t *testing.T) {
+	tests := []struct {
+		name          string
+		msgs          []Message
+		wantCount     int64
+		wantPartition string // "" means expect the attribute to be absent
+	}{
+		{name: "empty poll", msgs: nil, wantCount: 0, wantPartition: ""},
+		{name: "single message", msgs: []Message{{Partition: 3}}, wantCount: 1, wantPartition: "3"},
+		{
+			name:          "batch single partition",
+			msgs:          []Message{{Partition: 2}, {Partition: 2}, {Partition: 2}},
+			wantCount:     3,
+			wantPartition: "2",
+		},
+		{
+			name:          "batch multiple partitions",
+			msgs:          []Message{{Partition: 1}, {Partition: 2}},
+			wantCount:     2,
+			wantPartition: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			spanRecorder := tracetest.NewSpanRecorder()
+			tracerProvider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(spanRecorder))
+			defer func() { _ = tracerProvider.Shutdown(ctx) }()
+
+			_, span := tracerProvider.Tracer("test").Start(ctx, "poll test-topic")
+			setPollSpanAttrs(span, tt.msgs)
+			span.End()
+
+			ended := spanRecorder.Ended()
+			require.Len(t, ended, 1)
+			attrs := ended[0].Attributes()
+
+			count, ok := findAttr(attrs, "messaging.batch.message_count")
+			require.True(t, ok, "batch.message_count should always be set on a poll span")
+			assert.Equal(t, tt.wantCount, count.Value.AsInt64())
+
+			_, hasOffset := findAttr(attrs, "messaging.kafka.offset")
+			assert.False(t, hasOffset, "kafka.offset must not be set on a poll span")
+
+			partition, hasPartition := findAttr(attrs, "messaging.destination.partition.id")
+			if tt.wantPartition == "" {
+				assert.False(t, hasPartition, "partition.id should be absent for a mixed/empty batch")
+			} else {
+				require.True(t, hasPartition, "partition.id should be set for a single-partition batch")
+				assert.Equal(t, tt.wantPartition, partition.Value.AsString())
+			}
+		})
+	}
+}
+
+func findAttr(attrs []attribute.KeyValue, key string) (attribute.KeyValue, bool) {
+	for _, a := range attrs {
+		if string(a.Key) == key {
+			return a, true
+		}
+	}
+	return attribute.KeyValue{}, false
 }

--- a/kafkarator/telemetry_test.go
+++ b/kafkarator/telemetry_test.go
@@ -36,7 +36,7 @@ func TestStartProcessingSpanPropagatesBaggage(t *testing.T) {
 
 	msg := &Message{Topic: "test-topic", Headers: headers}
 
-	msgCtx, span := startProcessingSpan(ctx, tracer, "test-group", msg)
+	msgCtx, span := startProcessingSpan(ctx, tracer, "test-group", msg, serverInfo{})
 	defer span.End()
 
 	assert.Equal(t, "acme-corp", baggage.FromContext(msgCtx).Member("tenant.id").Value(),

--- a/kafkarator/writer.go
+++ b/kafkarator/writer.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
-	semconv "go.opentelemetry.io/otel/semconv/v1.38.0"
 	"go.opentelemetry.io/otel/semconv/v1.38.0/messagingconv"
 )
 
@@ -263,15 +262,11 @@ func (w *Writer) Write(ctx context.Context, message *Message, opts ...WriteOptio
 
 	if w.closed.Load() {
 		err := fmt.Errorf("writer is closed")
-		setSpanError(span, err)
+		setSpanStatus(span, err)
 		w.recordSendDuration(ctx, message.Topic, "", sendStart, err)
 		w.recordSent(ctx, message.Topic, "", err)
 		span.End()
 		return err
-	}
-
-	if message.Key != nil {
-		span.SetAttributes(semconv.MessagingKafkaMessageKey(string(message.Key)))
 	}
 
 	traceHeaders := injectTraceContext(ctx, message.Headers)
@@ -295,7 +290,7 @@ func (w *Writer) Write(ctx context.Context, message *Message, opts ...WriteOptio
 
 	err := w.producer.Produce(msg, deliveryChan)
 	if err != nil {
-		setSpanError(span, err)
+		setSpanStatus(span, err)
 		w.recordSendDuration(ctx, message.Topic, "", sendStart, err)
 		w.recordSent(ctx, message.Topic, "", err)
 		span.End()
@@ -327,6 +322,7 @@ func (w *Writer) Write(ctx context.Context, message *Message, opts ...WriteOptio
 		partitionID := fmt.Sprintf("%d", m.TopicPartition.Partition)
 		defer w.recordSent(ctx, message.Topic, partitionID, m.TopicPartition.Error)
 		defer w.recordSendDuration(ctx, message.Topic, partitionID, sendStart, m.TopicPartition.Error)
+		defer setSpanStatus(span, m.TopicPartition.Error)
 
 		if writeOpts.DeliveryChannel != nil {
 			defer func() {
@@ -339,8 +335,6 @@ func (w *Writer) Write(ctx context.Context, message *Message, opts ...WriteOptio
 		}
 
 		if m.TopicPartition.Error != nil {
-			setSpanError(span, m.TopicPartition.Error)
-
 			w.deliveryErrsMu.Lock()
 			if w.firstDeliveryErr == nil {
 				w.firstDeliveryErr = m.TopicPartition.Error
@@ -351,7 +345,7 @@ func (w *Writer) Write(ctx context.Context, message *Message, opts ...WriteOptio
 			return
 		}
 
-		setProducerSuccess(span, partitionID, int64(m.TopicPartition.Offset))
+		setProducerSpanAttrs(span, partitionID, int64(m.TopicPartition.Offset))
 	})
 
 	return nil

--- a/kafkarator/writer.go
+++ b/kafkarator/writer.go
@@ -67,11 +67,15 @@ func defaultWriteOptions() *WriteOptions {
 func newWriter(
 	p *kafka.Producer,
 	pmc messagingconv.ClientSentMessages,
+	opDur messagingconv.ClientOperationDuration,
+	srv serverInfo,
 	tel TelemetryProvider,
 ) *Writer {
 	w := &Writer{
 		producer:                p,
 		producedMessagesCounter: pmc,
+		operationDuration:       opDur,
+		srv:                     srv,
 		tel:                     tel,
 		done:                    make(chan struct{}),
 	}
@@ -90,6 +94,8 @@ func newWriter(
 // goroutines), wait for them all to return, then Flush or Close.
 type Writer struct {
 	producedMessagesCounter messagingconv.ClientSentMessages
+	operationDuration       messagingconv.ClientOperationDuration
+	srv                     serverInfo
 	producer                *kafka.Producer
 	tel                     TelemetryProvider
 	closed                  atomic.Bool
@@ -252,11 +258,14 @@ func (w *Writer) Write(ctx context.Context, message *Message, opts ...WriteOptio
 		return fmt.Errorf("message topic cannot be empty")
 	}
 
-	ctx, span := startProduceSpan(ctx, w.tel.Tracer(), message.Topic)
+	ctx, span := startProduceSpan(ctx, w.tel.Tracer(), message.Topic, w.srv)
+	sendStart := time.Now()
 
 	if w.closed.Load() {
 		err := fmt.Errorf("writer is closed")
-		setProducerError(span, err)
+		setSpanError(span, err)
+		w.recordSendDuration(ctx, message.Topic, "", sendStart, err)
+		w.recordSent(ctx, message.Topic, "", err)
 		span.End()
 		return err
 	}
@@ -286,7 +295,9 @@ func (w *Writer) Write(ctx context.Context, message *Message, opts ...WriteOptio
 
 	err := w.producer.Produce(msg, deliveryChan)
 	if err != nil {
-		setProducerError(span, err)
+		setSpanError(span, err)
+		w.recordSendDuration(ctx, message.Topic, "", sendStart, err)
+		w.recordSent(ctx, message.Topic, "", err)
 		span.End()
 		return fmt.Errorf("produce message: %w", err)
 	}
@@ -314,7 +325,8 @@ func (w *Writer) Write(ctx context.Context, message *Message, opts ...WriteOptio
 
 		m := ev.(*kafka.Message)
 		partitionID := fmt.Sprintf("%d", m.TopicPartition.Partition)
-		defer recordSentMessage(ctx, w.producedMessagesCounter, message.Topic, partitionID, m.TopicPartition.Error)
+		defer w.recordSent(ctx, message.Topic, partitionID, m.TopicPartition.Error)
+		defer w.recordSendDuration(ctx, message.Topic, partitionID, sendStart, m.TopicPartition.Error)
 
 		if writeOpts.DeliveryChannel != nil {
 			defer func() {
@@ -327,7 +339,7 @@ func (w *Writer) Write(ctx context.Context, message *Message, opts ...WriteOptio
 		}
 
 		if m.TopicPartition.Error != nil {
-			setProducerError(span, m.TopicPartition.Error)
+			setSpanError(span, m.TopicPartition.Error)
 
 			w.deliveryErrsMu.Lock()
 			if w.firstDeliveryErr == nil {
@@ -343,4 +355,27 @@ func (w *Writer) Write(ctx context.Context, message *Message, opts ...WriteOptio
 	})
 
 	return nil
+}
+
+// recordSendDuration records messaging.client.operation.duration for a send
+// operation (initiation → delivery report, or a synchronous failure).
+func (w *Writer) recordSendDuration(ctx context.Context, topic, partition string, start time.Time, err error) {
+	recordOperationDuration(
+		ctx,
+		w.operationDuration,
+		MessagingOperationNameSend,
+		messagingconv.OperationTypeSend,
+		topic,
+		"",
+		partition,
+		w.srv,
+		time.Since(start).Seconds(),
+		err,
+	)
+}
+
+// recordSent records one messaging.client.sent.messages for a delivered (or
+// failed) message.
+func (w *Writer) recordSent(ctx context.Context, topic, partition string, err error) {
+	recordSentMessage(ctx, w.producedMessagesCounter, topic, partition, w.srv, err)
 }


### PR DESCRIPTION
Bring producer/consumer metrics and spans in line with the OpenTelemetry messaging semantic conventions (semconv v1.38.0 / messagingconv).

Metrics:
- Emit all four messaging metrics (client.operation.duration, client.sent.messages, client.consumed.messages, process.duration) with required/conditional attributes.
- Set the ExplicitBucketBoundaries advisory on both duration histograms; the generated messagingconv constructors omit it, so seconds-scale latencies were falling into the SDK default (0–10000) buckets.
- Record operation.duration for commit (settle) and one receive operation.duration per Read, unconditionally, matching the poll span.
- Count sent/consumed messages on failure with error.type; successes are counted only after broker confirmation.
- Fix getErrorType to errors.As on kafka.Error (whose Code() returns ErrorCode, not int), so Kafka codes populate error.type instead of always falling back to _OTHER.

Spans:
- Record server.address/server.port on the send/poll/commit/process spans.
- Set error.type on failure across all four span types via a shared setSpanError helper (previously commit/process recorded the error event but never the error.type attribute).
- Restrict kafka.offset to single-message poll spans so batch poll spans no longer carry a single message's offset.

Wrap the per-call metric recorders in typed helper methods on Reader/Writer/Processor to remove positional-argument soup.