### PR TITLE
✨ name HTTP spans by route for non-stdlib routers

### DIFF
--- a/telemetry/provider.go
+++ b/telemetry/provider.go
@@ -145,9 +145,26 @@ func (p *Provider) LoggerProvider() log.LoggerProvider {
 	return p.loggerProvider
 }
 
+// HTTPOption configures the HTTP middleware returned by [Provider.HTTPMiddleware].
+type HTTPOption func(*httpConfig)
+
+type httpConfig struct {
+	routeResolver func(*http.Request) string
+}
+
+// WithRouteResolver supplies a function that returns the matched route template for a request.
+func WithRouteResolver(fn func(*http.Request) string) HTTPOption {
+	return func(c *httpConfig) { c.routeResolver = fn }
+}
+
 // HTTPMiddleware constructs a plain http middleware that instruments incoming
 // requests with traces and metrics.
-func (p *Provider) HTTPMiddleware() func(http.Handler) http.Handler {
+func (p *Provider) HTTPMiddleware(opts ...HTTPOption) func(http.Handler) http.Handler {
+	cfg := &httpConfig{}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
 	otelMW := otelhttp.NewMiddleware("http-server",
 		otelhttp.WithPropagators(p.propagator),
 		otelhttp.WithTracerProvider(p.tracerProvider),
@@ -160,23 +177,28 @@ func (p *Provider) HTTPMiddleware() func(http.Handler) http.Handler {
 		}),
 	)
 	return func(h http.Handler) http.Handler {
-		return otelMW(labelerMiddleware(h))
+		return otelMW(routeMiddleware(cfg, h))
 	}
 }
 
-func labelerMiddleware(next http.Handler) http.HandlerFunc {
+func routeMiddleware(cfg *httpConfig, next http.Handler) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		next.ServeHTTP(w, r)
+
+		if r.Pattern == "" && cfg.routeResolver != nil {
+			if route := cfg.routeResolver(r); route != "" {
+				r.Pattern = r.Method + " " + route
+			}
+		}
+
 		labeler, _ := otelhttp.LabelerFromContext(r.Context())
 
 		// Stripping the method to leave only the route
-		_, route, found := strings.Cut(r.Pattern, " ")
-		if found {
+		if _, route, found := strings.Cut(r.Pattern, " "); found {
 			labeler.Add(semconv.HTTPRoute(route))
 		} else if r.Pattern != "" {
 			labeler.Add(semconv.HTTPRoute(r.Pattern))
 		}
-
-		next.ServeHTTP(w, r)
 	}
 }
 


### PR DESCRIPTION
Kontekst: 
`Trace Name` blir satt til `GET 404 Not Found` [her](https://grafana.test.happi.hafslund.no/a/grafana-exploretraces-app/explore?from=now-6h&to=now&timezone=browser&var-ds=tempo&var-primarySignal=nestedSetParent%3C0&var-filters=resource.service.name%7C%3D%7Ccarbonic-api&var-filters=resource.service.namespace%7C%3D%7Ccarbonic-test&var-metric=rate&var-groupBy=resource.k8s.namespace.name&var-spanListColumns=&var-latencyThreshold=&var-partialLatencyThreshold=&actionView=traceList&var-durationPercentiles=0.9)

Dette kommer [herfra](https://github.com/hafslundkraft/golib/blob/main/telemetry/provider.go#L155-L158)

`r.Pattern` blir satt i go standard lib men ikke [chi](https://github.com/go-chi/chi) (som er det vi bruker) eller andre 3-parts routere. Foreslår derfor en "bring your own route resolver" løsning. Kalleren oppgir hvordan ruta hentes
ut av sin router, og golib fyller `r.Pattern` fra den, slik at otelhttps egen
omdøping slår inn.

For vår del blir konsekvensene:

Gammel oppsett
```go
router.Use(tel.HTTPMiddleware())
```

Nytt:
```go
router.Use(tel.HTTPMiddleware(
    telemetry.WithRouteResolver(func(r *http.Request) string {
        return chi.RouteContext(r.Context()).RoutePattern()
    }),
))
```

